### PR TITLE
Unexpected behaviour of machina.Fsm.extend with multiple 'childs'

### DIFF
--- a/lib/node/machina.js
+++ b/lib/node/machina.js
@@ -47,7 +47,7 @@ var _ = require( 'underscore' );
 					obj[sourcePropKey] = sourcePropVal;
 				},
 				"object" : function ( obj, sourcePropKey, sourcePropVal ) {
-					obj[sourcePropKey] = deepExtend( obj[sourcePropKey] || {}, sourcePropVal );
+					obj[sourcePropKey] = deepExtend( {}, sourcePropVal );
 				},
 				"array" : function ( obj, sourcePropKey, sourcePropVal ) {
 					obj[sourcePropKey] = [];

--- a/spec/machina.fsm.spec.js
+++ b/spec/machina.fsm.spec.js
@@ -581,6 +581,50 @@ describe( "machina.Fsm", function () {
 		} );
 	} );
 
+    describe( "When extending an FSM contructor twice with overriden state & handlers", function () {
+        var Base = machina.Fsm.extend({
+            initialState: 'S',
+            states: {
+                S: {
+                    action1: function () {
+                    },
+                    action2: function () {
+                    }
+                }
+            }
+        });
+
+        var Extend1 = Base.extend({
+            states: {
+                S: {
+                    action1: function () {
+                    }
+                }
+            }
+        });
+
+        var Extend2 = Base.extend({
+            states: {
+                S: {
+                    action2: function () {
+                    }
+                }
+            }
+        });
+
+        var b1 = new Base();
+        var e1 = new Extend1();
+        var e2 = new Extend2();
+
+        it( "should produce instances that have distinct action handlers", function () {
+            expect( b1.states.S.action1 !== e1.states.S.action1 );
+            expect( b1.states.S.action2 !== e2.states.S.action2 );
+
+            expect( e1.states.S.action1 !== e2.states.S.action1 );
+            expect( e1.states.S.action2 !== e2.states.S.action2 );
+        });
+    });
+
 	describe( "When providing a global catch-all handler", function () {
 		var catchAllHandled = [],
 			stateSpecificCatchAllHandled = [];


### PR DESCRIPTION
When you create a constructor with machina.Fsm.extend and then extend it with overwritten  handlers it will change the base constructor's handler as well.
This seems counter-intuitive and IMO is a bug.

See added test in spec file.
