### PR TITLE
Added the ability for handlers to transition by returning a string value.

### DIFF
--- a/spec/machina.fsm.spec.js
+++ b/spec/machina.fsm.spec.js
@@ -87,7 +87,7 @@ describe( "machina.Fsm", function () {
 				expect( events.transitionedHandler ).to.be( true );
 			} );
 			it( "transition event should be the correct structure", function() {
-				expect( payloads.transitionedHandler).to.eql({ fromState: "uninitialized", toState: "initialized" });
+				expect( payloads.transitionedHandler).to.eql({ fromState: "uninitialized", action: "uninitialized.event1", toState: "initialized" });
 			} );
 			it( "should fire the nohandler event", function () {
 				expect( events.noHandlerInvoked ).to.be( true );
@@ -507,6 +507,43 @@ describe( "machina.Fsm", function () {
 		it( "should transition into the started state", function () {
 			expect( transitioned ).to.be( true );
 		} );
+	} );
+
+	describe( "A handler function should be able to delegate to another handler.", function () {
+		var transitioned = false;
+		var fsm = new machina.Fsm( {
+			initialState : "notstarted",
+			states : {
+				notstarted : {
+					"delegate" : function() {
+						this.handle( "start" ) ;
+					},
+					"start" : function() {
+						this.transition( "started" );
+					}
+				},
+				started : {
+					_onEnter : function () {
+						transitioned = true;
+					}
+				}
+			}
+		} );
+
+		var transitionPayload;
+		fsm.on( "transition", function (x) {
+			transitionPayload = x;
+		});
+
+		fsm.handle( "delegate" );
+
+		it( "should have transitioned into the started state", function () {
+			expect( transitioned ).to.be( true );
+		} );
+		it( "transition's action should be the initial handler", function () {
+			expect( transitionPayload ).to.eql({ fromState: "notstarted", action: "notstarted.delegate", toState: "started" });
+		} );
+
 	} );
 
 

--- a/src/fsm.js
+++ b/src/fsm.js
@@ -37,18 +37,20 @@ _.extend( Fsm.prototype, {
 	},
 	handle : function ( inputType ) {
 		if ( !this.inExitHandler ) {
-			var states = this.states, current = this.state, args = slice.call( arguments, 0 ), handlerName, handler, catchAll;
+			var states = this.states, current = this.state, args = slice.call( arguments, 0 ), handlerName, handler, catchAll, action;
 			this.currentActionArgs = args;
 			if ( states[current][inputType] || states[current]["*"] || this[ "*" ] ) {
 				handlerName = states[current][inputType] ? inputType : "*";
 				catchAll = handlerName === "*";
 				if ( states[current][handlerName] ) {
 					handler = states[current][handlerName];
-					this._currentAction = current + "." + handlerName;
+					action = current + "." + handlerName;
 				} else {
 					handler = this[ "*" ];
-					this._currentAction = "*";
+					action = "*";
 				}
+				if ( ! this._currentAction ) 
+					this._currentAction = action ;
 				this.emit.call( this, HANDLING, { inputType: inputType, args: args.slice(1) } );
 				if (_.isFunction(handler))
 					handler = handler.apply( this, catchAll ? args : args.slice( 1 ) );
@@ -78,7 +80,7 @@ _.extend( Fsm.prototype, {
 					this.states[oldState]._onExit.call( this );
 					this.inExitHandler = false;
 				}
-				this.emit.call( this, TRANSITION, { fromState: oldState, toState: newState } );
+				this.emit.call( this, TRANSITION, { fromState: oldState, action: this._currentAction, toState: newState } );
 				if ( this.states[newState]._onEnter ) {
 					this.states[newState]._onEnter.call( this );
 				}


### PR DESCRIPTION
I've been using machina.js to build an (Ember-like) state machine based Router for Backbone.

It is working quite well, but one thing that got visually ugly was when I was switching to different states based on application state.

That's why I added the ability to transition to a state based on the handler's return value, turning this:

``` javascript
"complex": function() {
  if ( specialCase ) {
    this.transition("error");
  } else {
    this.transition(lastStep ? "finish" : "continue" ) ;
  },
},
"simple": function() { 
  this.transition(answered ? "answer" : "record") ; 
},
```

into

``` javascript
"complex": function() {
  if (specialCase) return "error";
  return lastStep ? "finish" : "continue" ;
},
"simple": function() { return answered ? "answer" : "record" },
```
