### PR TITLE
Remove requirement to inject underscore in node

### DIFF
--- a/src/machina.js
+++ b/src/machina.js
@@ -2,6 +2,7 @@
 	if ( typeof module === "object" && module.exports ) {
 		// Node, or CommonJS-Like environments
 		module.exports = function ( _ ) {
+			_ = _ || require('underscore')
 			return factory( _ );
 		};
 	} else if ( typeof define === "function" && define.amd ) {


### PR DESCRIPTION
It seems unnecessary to require people to install underscore when it's already a dependency of machina.
