### PR TITLE
fix module require line when used with node.js

### DIFF
--- a/lib/machina.js
+++ b/lib/machina.js
@@ -10,7 +10,7 @@
 		module.exports = function ( _ ) {
 			_ = _ || require( 'underscore' );
 			return factory( _ );
-		};
+		}();
 	} else if ( typeof define === "function" && define.amd ) {
 		// AMD. Register as an anonymous module.
 		define( ["underscore"], function ( _ ) {


### PR DESCRIPTION
Instead of:
machina=require('machina')()
you now do:
machina=require('machina')
which is how node modules are usually require'd
