### PR TITLE
Updating component.json to reflect Component instead of Bower

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,8 +1,11 @@
 {
-	"name"    : "machina.js",
-	"version" : "0.3.4",
-	"main"    : ["lib/browser/machina.js"],
-	"dependencies": {
-		"underscore": "~1.1.7"
-	}
+  "name": "machina.js",
+  "version": "0.3.4",
+  "main": "lib/machina.js",
+  "scripts": [
+    "lib/machina.js"
+  ],
+  "dependencies": {
+    "component/underscore": "*"
+  }
 }


### PR DESCRIPTION
Another PR (#19) using `bower.json` has been created, so this one "complements" that one by re-structuring `component.json` specific to Component.js
