### PR TITLE
Changes the reference to resources in test.html

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1,14 +1,14 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
-    <link rel="stylesheet" href="/ext/mocha.css" />
+    <link rel="stylesheet" href="../ext/mocha.css" />
 </head>
 <body>
     <div id="mocha"></div>
-<script src="/ext/jquery-1.7.1.js"></script>
-<script src="/ext/underscore.js"></script>
-<script src="/ext/expect.js"></script>
-<script src="/ext/mocha.js"></script>
+<script src="../ext/jquery-1.7.1.js"></script>
+<script src="../ext/underscore.js"></script>
+<script src="../ext/expect.js"></script>
+<script src="../ext/mocha.js"></script>
 <script type="text/javascript">
     mocha.setup({ ui: 'bdd', timeout: 60000, ignoreLeaks: true });
 </script>


### PR DESCRIPTION
Right now, you can't directly open `spec/index.html` in a browser to run the tests. This update allows you to do that without breaking the ability to run `anvil`.
