### PR TITLE
Utilizes bower in test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ desktop.ini
 .anvil
 *node_modules*
 *npm-debug*
+bower_components/

--- a/bower.json
+++ b/bower.json
@@ -4,10 +4,13 @@
   "main": [
     "lib/browser/machina.js"
   ],
-  "dependencies": {
-    "underscore": "~1.1.7"
-  },
   "ignore": [
     "**/.*"
-  ]
+  ],
+  "devDependencies": {
+    "jquery": "~1.7.1",
+    "underscore": "~1.5.2",
+    "mocha": "~1.17.0",
+    "expect": "~0.2.0"
+  }
 }

--- a/spec/index.html
+++ b/spec/index.html
@@ -1,14 +1,14 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
-    <link rel="stylesheet" href="/ext/mocha.css" />
+    <link rel="stylesheet" href="bower_components/mocha/mocha.css" />
 </head>
 <body>
     <div id="mocha"></div>
-<script src="/ext/jquery-1.7.1.js"></script>
-<script src="/ext/underscore.js"></script>
-<script src="/ext/expect.js"></script>
-<script src="/ext/mocha.js"></script>
+<script src="bower_components/jquery/jquery.js"></script>
+<script src="bower_components/underscore/underscore.js"></script>
+<script src="bower_components/expect/expect.js"></script>
+<script src="bower_components/mocha/mocha.js"></script>
 <script type="text/javascript">
     mocha.setup({ ui: 'bdd', timeout: 60000, ignoreLeaks: true });
 </script>


### PR DESCRIPTION
This is an initial PR to illustrate how bower can be utilized. The `ext` folder is unchanged, but now the testing suite depends on the installed bower components, and not the files in `ext`. I also went ahead and updated Underscore to the latest version. jQuery might also be considered for upgrades to `~1.11.0`.

I suggest completely removing `ext`, and setting the dependencies to just be from `bower`. Then it's super easy to keep things up to date and it makes your repo have less unnecessary bloat. If you'd like me to do this I can go ahead and move forward with it, though I'm not sure how to work with anvil.
