### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "machina.js",
   "version": "0.3.5",
   "main": [
-    "lib/browser/machina.js"
+    "lib/machina.js"
   ],
   "dependencies": {
     "underscore": "~1.5.2"


### PR DESCRIPTION
Fix path of `main` option so that when using Grunt's bower-install task it points to the correct file.
