### PR TITLE
Using the official Underscore dependency in component.json

### DIFF
--- a/component.json
+++ b/component.json
@@ -6,6 +6,6 @@
         "lib/machina.js"
     ],
     "dependencies": {
-        "component/underscore": "*"
+        "jashkenas/underscore": "*"
     }
 }


### PR DESCRIPTION
I figure using the "official" version of a dependency is preferred, since `component/*` forks were always meant to be temporary.
