### PR TITLE
Fixing case where objects in options had their prototype chains broken

### DIFF
--- a/lib/machina.js
+++ b/lib/machina.js
@@ -313,9 +313,8 @@
             fsm = protoProps.constructor;
         } else {
             fsm = function () {
-                var args = slice.call(arguments, 0);
-                args[0] = _.deepExtend(_.cloneDeep(instanceProps), args[0]);
-                parent.apply(this, args);
+                _.extend(this, _.cloneDeep(instanceProps));
+                parent.apply(this, arguments);
             };
         }
 


### PR DESCRIPTION
The usage of `deepExtend` is not necessary here, at least not in my opinion. Not only that, but it breaks the prototype chain if you pass an object that was created via `new` (this probably affects objects initialized via `Object.create` too) as part of the configuration `options`.
