### PR TITLE
FSM fixing instance properties during init

### DIFF
--- a/src/fsm.js
+++ b/src/fsm.js
@@ -234,14 +234,7 @@ var inherits = function( parent, protoProps, staticProps ) {
     // Add prototype properties (instance properties) to the subclass,
     // if supplied.
     if ( protoProps ) {
-        _.extend(
-            fsm.prototype,
-            _.transform( protoProps, function( accum, val, key ) {
-                if ( typeof val === "function" ) {
-                    accum[ key ] = val;
-                }
-            } )
-        );
+        _.extend(fsm.prototype, protoProps);
         _.deepExtend( machObj, _.transform( protoProps, function( accum, val, key ) {
             if ( _machKeys.indexOf( key ) !== -1 ) {
                 accum[ key ] = val;


### PR DESCRIPTION
This change means to allow FSM instances to also allow prototype properties, not just methods. The exclusion of properties disallowed setting default values and sharing values between instances, the entire point of prototypal inheritance.

The same behavior that extends the `FSM.state` objects remains intact, and all tests continue to pass.
