### PR TITLE
Inherited FSM's using constructors with parameters lose the base FSM states

### DIFF
--- a/spec/machina.fsm.spec.js
+++ b/spec/machina.fsm.spec.js
@@ -1025,5 +1025,107 @@
                 } );
             } );
         } );
+
+        describe("When inheriting a base FSM", function () {
+            describe("using a parameterless constructor", function () {
+                var BaseFsm = machina.Fsm.extend({
+                    states: {
+                        a: {},
+                        b: {}
+                    },
+                    methodA: function () {}
+                });
+
+                var SubFsm = BaseFsm.extend({
+                    states: {
+                        c: {}
+                    },
+                    methodB: function () {}
+                });
+
+                describe("the base class", function () {
+                    it("should have the base states", function () {
+                        var base = new BaseFsm();
+
+                        expect(base.states).to.have.property('a');
+                        expect(base.states).to.have.property('b');
+                    });
+
+                    it("should have the base methods", function () {
+                        var base = new BaseFsm();
+
+                        expect(base.methodA).to.be.a('function');
+                    });
+                });
+
+                describe("the sub class", function () {
+                    it("should have the base and sub states", function () {
+                        var sub = new SubFsm();
+
+                        expect(sub.states).to.have.property('a');
+                        expect(sub.states).to.have.property('b');
+                        expect(sub.states).to.have.property('c');
+                    });
+
+                    it("should have the base and sub methods", function () {
+                        var sub = new SubFsm();
+
+                        expect(sub.methodA).to.be.a('function');
+                        expect(sub.methodB).to.be.a('function');
+                    });
+                });
+            });
+
+            describe("using a parameterized constructor", function () {
+                var BaseFsm = machina.Fsm.extend({
+                    initialize: function (parameter) {
+                    },
+                    states: {
+                        a: {},
+                        b: {}
+                    },
+                    methodA: function () {}
+                });
+
+                var SubFsm = BaseFsm.extend({
+                    states: {
+                        c: {}
+                    },
+                    methodB: function () {}
+                });
+
+                describe("the base class", function () {
+                    it("should have the base and sub states", function () {
+                        var base = new BaseFsm('parameter');
+
+                        expect(base.states).to.have.property('a');
+                        expect(base.states).to.have.property('b');
+                    });
+
+                    it("should have the base and sub methods", function () {
+                        var base = new BaseFsm('parameter');
+
+                        expect(base.methodA).to.be.a('function');
+                    });
+                });
+
+                describe("the sub class", function () {
+                    it("should have the base and sub states", function () {
+                        var sub = new SubFsm('parameter');
+
+                        expect(sub.states).to.have.property('a');
+                        expect(sub.states).to.have.property('b');
+                        expect(sub.states).to.have.property('c');
+                    });
+
+                    it("should have the base and sub methods", function () {
+                        var sub = new SubFsm('parameter');
+
+                        expect(sub.methodA).to.be.a('function');
+                        expect(sub.methodB).to.be.a('function');
+                    });
+                });
+            });
+        });
     } );
 }() );

--- a/spec/machina.fsm.spec.js
+++ b/spec/machina.fsm.spec.js
@@ -1079,6 +1079,7 @@
             describe("using a parameterized constructor", function () {
                 var BaseFsm = machina.Fsm.extend({
                     initialize: function (parameter) {
+                        this.parameter = parameter;
                     },
                     states: {
                         a: {},
@@ -1107,6 +1108,12 @@
 
                         expect(base.methodA).to.be.a('function');
                     });
+
+                    it('should initialize with the given parameters', function () {
+                        var base = new BaseFsm('parameter');
+
+                        expect(base.parameter).to.eql('parameter');
+                    });
                 });
 
                 describe("the sub class", function () {
@@ -1123,6 +1130,12 @@
 
                         expect(sub.methodA).to.be.a('function');
                         expect(sub.methodB).to.be.a('function');
+                    });
+
+                    it("should initialize with the given parameters", function () {
+                        var sub = new SubFsm('parameter');
+
+                        expect(sub.parameter).to.eql('parameter');
                     });
                 });
             });


### PR DESCRIPTION
I've added some tests demonstrating the loss of base class states in inherited classes which use constructors with parameters.

From the issue tracker and documentation it looks like the 0.4.0+ is going through some changes related to inheritance but I wanted to get this on your radar in the event there is a quick fix or another way to utilize constructors with parameters.

Please let me know if you need any more information.  I'll look into fixes as well in the interim.

Thanks!