### PR TITLE
Update lodash 3.x paths in examples to fix #97, fix #99

### DIFF
--- a/example/atm/index.html
+++ b/example/atm/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>ATM State Machine Example</title>
 	<link rel="stylesheet" type="text/css" href="style.css">
-	<script type="text/javascript" src="../../bower/lodash/dist/lodash.js"></script>
+	<script type="text/javascript" src="../../bower/lodash/lodash.js"></script>
 	<script type="text/javascript" src="../../bower/jquery/jquery.min.js"></script>
 	<script type="text/javascript" src="../../bower/backbone/backbone-min.js"></script>
 	<script type="text/javascript" src="/ext/infuser_all.js"></script>

--- a/example/connectivity/js/main.js
+++ b/example/connectivity/js/main.js
@@ -2,8 +2,8 @@ require.config( {
 	paths: {
 		text: "../../../bower/requirejs-text/text",
 		backbone: '../../../bower/backbone/backbone',
-		lodash: '../../../bower/lodash/dist/lodash',
-		underscore: '../../../bower/lodash/dist/lodash.underscore',
+		lodash: '../../../bower/lodash/lodash',
+		underscore: '../../../bower/lodash/lodash.underscore',
 		mockjax: '../../../bower/jquery-mockjax/jquery.mockjax',
 		machina: '/lib/machina',
 		'machina.postal': '../../../bower/machina.postal/lib/machina.postal',

--- a/example/hierarchical/index.html
+++ b/example/hierarchical/index.html
@@ -9,7 +9,7 @@
 
 	</div>
 	<script type="text/javascript" src="../../bower/jquery/jquery.min.js"></script>
-	<script type="text/javascript" src="../../bower/lodash/dist/lodash.js"></script>
+	<script type="text/javascript" src="../../bower/lodash/lodash.js"></script>
 	<script type="text/javascript" src="../../lib/machina.js"></script>
 	<script type="text/javascript" src="js/main.js"></script>
 </body>

--- a/example/load/index.html
+++ b/example/load/index.html
@@ -3,7 +3,7 @@
 <head>
 	<title>FSM App Load Example</title>
 	<link rel="stylesheet" type="text/css" href="style.css">
-	<script type="text/javascript" src="../../bower/lodash/dist/lodash.js"></script>
+	<script type="text/javascript" src="../../bower/lodash/lodash.js"></script>
 	<script type="text/javascript" src="../../bower/jquery/jquery.min.js"></script>
 	<script type="text/javascript" src="../../ext/infuser_all.js"></script>
 	<script type="text/javascript" src="../../bower/conduitjs/lib/conduit.js"></script>


### PR DESCRIPTION
Paths to lodash.js changed in 3.0.0
https://github.com/lodash/lodash/wiki/Changelog#v300

Fixes problems for examples introduced by #83 and 46dcdf362f1b8deb6e76c325d1bf097aa6fb8820.