### PR TITLE
Using `<base href="http://...">` breaks over HTTPS

### DIFF
--- a/example/connectivity/index.html
+++ b/example/connectivity/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 	<title>Connectivity FSM Example</title>
-    <base href="http://ifandelse.github.io/machina.js/example/connectivity/">
+    <base href="//ifandelse.github.io/machina.js/example/connectivity/">
 	<meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0">
 	<link rel="stylesheet" type="text/css" href="css/style.css">
 	<script src="./js/modernizr.js"></script>

--- a/example/hierarchical/index.html
+++ b/example/hierarchical/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 	<title>Hierarchical FSM Example</title>
-    <base href="http://ifandelse.github.io/machina.js/example/hierarchical/">
+    <base href="//ifandelse.github.io/machina.js/example/hierarchical/">
 </head>
 <body>
 	<div style="border-bottom: 1pt solid navy;">Alas, one day I will have a real example app for this....</div>


### PR DESCRIPTION
Using a base href with `http` as a hardcoded schema breaks when accessing the examples over HTTPS, because of browser security settings.

See http versus https
http://ifandelse.github.io/machina.js/example/connectivity/
https://ifandelse.github.io/machina.js/example/connectivity/

Schema-less/schema-relative URLs should fix this.

``` html
<base href="//ifandelse.github.io/machina.js/example/hierarchical/">
```

As `master` and `gh-pages` have diverged, local testing isn't affected -- except when considering maintenance.
