### PR TITLE
Remove '.' from makeFsmNamespace function

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -177,7 +177,7 @@ var utils = {
 	makeFsmNamespace: ( function() {
 		var machinaCount = 0;
 		return function() {
-			return "fsm." + machinaCount++;
+			return "fsm" + machinaCount++;
 		};
 	} )(),
 	listenToChild: listenToChild,


### PR DESCRIPTION
Removed '.' from the generated namespace to enable saving __machina__ data in MongoDB.