### PR TITLE
Remove unnecessary child FSM creation by only instantiating upon transitions

### DIFF
--- a/src/BehavioralFsm.js
+++ b/src/BehavioralFsm.js
@@ -27,7 +27,7 @@ _.extend( BehavioralFsm.prototype, {
 		this.transition( client, initialState );
 	},
 
-	configForState: function configForState( newState ) {
+	configForState: function configForState( newState, instantiateClient ) {
 		var newStateObj = this.states[ newState ];
 		var child;
 		_.each( this.hierarchy, function( childListener, key ) {
@@ -37,7 +37,10 @@ _.extend( BehavioralFsm.prototype, {
 		} );
 
 		if ( newStateObj._child ) {
-			newStateObj._child = utils.getChildFsmInstance( newStateObj._child );
+			if ( instantiateClient ) {
+				newStateObj._child = utils.getChildFsmInstance( newStateObj._child );
+			}
+
 			child = newStateObj._child && newStateObj._child.instance;
 			this.hierarchy[ child.namespace ] = utils.listenToChild( this, child );
 		}
@@ -106,7 +109,7 @@ _.extend( BehavioralFsm.prototype, {
 		var result;
 		var action;
 		if ( !clientMeta.inExitHandler ) {
-			child = this.configForState( currentState );
+			child = this.configForState( currentState, false );
 			if ( child && !this.pendingDelegations[ inputDef.ticket ] && !inputDef.bubbling ) {
 				inputDef.ticket = ( inputDef.ticket || utils.createUUID() );
 				inputDef.delegated = true;
@@ -156,7 +159,7 @@ _.extend( BehavioralFsm.prototype, {
 		var args = utils.getLeaklessArgs( arguments ).slice( 2 );
 		if ( !clientMeta.inExitHandler && newState !== curState ) {
 			if ( newStateObj ) {
-				child = this.configForState( newState );
+				child = this.configForState( newState, true );
 				if ( curStateObj && curStateObj._onExit ) {
 					clientMeta.inExitHandler = true;
 					curStateObj._onExit.call( this, client );


### PR DESCRIPTION
This fixes the second issue that I mentioned in #154; it ensures that new child FSMs are only instantiated when transitioning to a new child-containing state, not when eg. `handle`ing a command that's received by a child.

As before, I've created a bugcase to demonstrate it, including an example of the erroneous results: https://git.cryto.net/joepie91/machina-factory-bugcase/src/child-switch

Of note:

* I'm unsure how to write a good test for this particular behaviour, so I've included no tests with this PR. Existing tests pass, however.
* I've not included built files in `lib/` in this PR due to merge conflict risks.
* I've left the 'detach and reattach event listeners' bit alone; that still happens regardless of whether a new FSM is instantiated or not. I was not confident enough in my understanding of its purpose in machina.js to do that conditionally as well. Depending on what it's used for, you may want to change that behaviour to avoid potentially missing events.