### PR TITLE
feat(examples): add job-queue rehydrate() showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ machina.js/
     traffic-intersection/ # hierarchical FSM with child states
     dungeon-critters/     # createBehavioralFsm example
     shopping-cart/        # defer() showcase
+    job-queue/            # BehavioralFsm rehydrate() persist/restore pattern
     with-react/           # React integration example
     machina-explorer/     # interactive FSM inspector + diagram visualizer
     testing-with-machina-test/ # machina-test matcher usage examples

--- a/docs/briefs/job-queue-example.md
+++ b/docs/briefs/job-queue-example.md
@@ -1,0 +1,112 @@
+# Product Brief: Job Queue Example App
+
+## Problem Statement
+
+machina v6 added `rehydrate()` to BehavioralFsm — a method for silently placing a previously-serialized client at a known state without triggering lifecycle hooks or events. There is no example in the codebase that demonstrates this feature. Developers discovering `rehydrate` in the docs or API reference have no runnable reference implementation showing the persist/restore pattern.
+
+The existing examples cover other BehavioralFsm features (dungeon-critters demonstrates per-client state tracking), but none involve serialization, persistence, or cold resume.
+
+## Target User
+
+machina developers who want to understand how and when to use `rehydrate()` on a BehavioralFsm. They already understand machina's core concepts (states, transitions, handlers) and are evaluating the behavioral pattern for workflows that need persistence.
+
+## MVP Scope
+
+A web-based example app that lives in `examples/job-queue/` and demonstrates the `rehydrate()` persist/restore cycle as its centerpiece.
+
+### Domain
+
+A simulated job queue. Jobs are client objects driven by a single BehavioralFsm. Job "work" is simulated via timers — no real async operations.
+
+### States (5, flat — no child FSMs)
+
+- **queued** — job is waiting to be processed
+- **processing** — job is actively running (simulated progress: step N of M)
+- **paused** — user-initiated pause; job frozen mid-workflow
+- **failed** — job encountered a simulated error; can be retried
+- **completed** — job finished successfully (terminal state)
+
+### Persistence
+
+- Auto-persist to localStorage on every state transition (subscribe to `transitioned` event)
+- On page load, read localStorage and restore all jobs via `rehydrate()`
+- "Clear Storage" button wipes localStorage and resets the UI to a fresh state — provides the "control group" contrast for the rehydrate demo
+
+### UI / Interaction
+
+- "Add Job" button creates a new client and queues it
+- Each job displayed as a card/row showing: job name/id, current state, progress indicator (when processing)
+- Per-job action buttons contextual to current state:
+    - queued: Start
+    - processing: Pause
+    - paused: Resume
+    - failed: Retry
+    - completed: (no actions — terminal)
+- "Clear Storage" button (prominent, clearly labeled)
+- Visual indication when jobs have been restored from storage (so the viewer knows rehydrate happened, not just "the page remembered stuff")
+
+### Tech Stack (matching existing examples)
+
+- Vanilla TypeScript, no framework
+- Vite build
+- Plain CSS with custom properties
+- Single page
+- File structure follows existing convention: `fsm.ts`, `config.ts`, `ui.ts`, `main.ts`, `style.css`, `fsm.test.ts`
+
+### Polish Level
+
+Conference talk or better. Consistent with shopping-cart, traffic-intersection, connectivity, and dungeon-critters examples in visual quality and code organization.
+
+## Explicitly Out of Scope
+
+- **Child FSMs / hierarchical state** — flat FSM only. Composite dot-path rehydration is documented separately.
+- **Real async work** — no network requests, file operations, or CPU-bound tasks. Jobs are simulated.
+- **Server-side persistence** — localStorage only. No database, no API.
+- **React or any UI framework** — vanilla DOM manipulation, per existing example conventions.
+- **Job configuration/editing** — no custom step counts, no priority, no scheduling. Jobs are uniform.
+- **Production job queue features** — no concurrency limits, no dependency graphs, no dead letter queues.
+- **machina-inspect or eslint-plugin-machina integration** — this example focuses on runtime behavior, not static analysis.
+
+## User Stories
+
+- As a machina developer, I want to see a working example of `rehydrate()` so that I understand the persist/restore pattern without reading source code.
+    - Acceptance Criteria:
+        - [ ] Page loads with no jobs on first visit (empty localStorage)
+        - [ ] "Add Job" creates a new job client and renders it in the UI
+        - [ ] Jobs transition through states via UI buttons (Start, Pause, Resume, Retry)
+        - [ ] Processing jobs show visible progress (step indicator or progress bar)
+        - [ ] Processing jobs can encounter simulated failure
+
+- As a machina developer, I want to see state survive a page refresh so that I understand what `rehydrate()` does.
+    - Acceptance Criteria:
+        - [ ] State is auto-persisted to localStorage on every transition
+        - [ ] Refreshing the page restores all jobs at their persisted states via `rehydrate()`
+        - [ ] A job that was mid-processing resumes from its paused/processing state, not from the beginning
+        - [ ] The UI visually indicates that jobs were restored from storage (not fresh-initialized)
+
+- As a machina developer, I want to see the contrast between a fresh start and a restored start so that I understand what happens without `rehydrate()`.
+    - Acceptance Criteria:
+        - [ ] "Clear Storage" button wipes localStorage and resets the UI
+        - [ ] After clearing, a refresh shows an empty job queue (no restoration)
+
+## Edge Cases & Open Questions
+
+- **What happens when the FSM definition changes between persist and restore?** If a developer adds/removes states and then loads stale localStorage data, `rehydrate()` will throw (invalid state). The example should handle this gracefully — clear stale storage and start fresh, with a visible message explaining why.
+- **Processing jobs and page refresh timing.** A job mid-processing has a timer running. On refresh, the timer is gone. Should a restored "processing" job auto-resume its timer, or come back as "paused"? Persisting as "processing" and auto-resuming the timer on rehydrate demonstrates the pattern more completely — but the choice should be made during architecture.
+- **localStorage size limits.** Not a real concern for a demo with a handful of jobs, but the example shouldn't encourage unbounded job creation. A reasonable cap (e.g., 20 jobs) or a "clear completed" button would prevent confusion.
+- **Job identity across serialization.** Clients are plain objects. After `JSON.parse`, they're new object references. The example needs to make clear that `rehydrate()` is registering a _new_ object in the WeakMap — it's not "reconnecting" to an old reference.
+
+## Success Metrics
+
+- A developer who has never used `rehydrate()` can read the example code and understand the persist/restore cycle in under 10 minutes.
+- The "refresh and it comes back" moment is immediately visible and understandable without reading code.
+- The example runs in the machina docs site without modification.
+
+## Handoff Notes for Architect
+
+- Follow the file structure convention established by existing web examples: `fsm.ts`, `config.ts`, `ui.ts`, `main.ts`, `style.css`, `fsm.test.ts`.
+- `main.ts` is wiring only — no business logic, no DOM manipulation. Subscribe to FSM events, delegate to `ui.ts`.
+- The FSM definition in `fsm.ts` should be clean enough to read as documentation. This is a teaching example — code clarity trumps DRYness.
+- The rehydrate proposal is at `docs/proposals/rehydrate-behavioral-fsm.md`. The dev report is at `docs/archive/reports/dev-report-rehydrate-behavioral-fsm.md`.
+- The persist/restore logic is the showcase. Make it prominent in the code — not buried in a utility. A reader skimming `main.ts` should immediately see the `rehydrate()` call and understand the flow.
+- localStorage serialization is the caller's responsibility. machina provides `compositeState()` for reading state and `rehydrate()` for writing it back. The example should use `currentState()` (not `compositeState()`) since the FSM is flat.

--- a/docs/build-plans/job-queue-example.md
+++ b/docs/build-plans/job-queue-example.md
@@ -1,0 +1,229 @@
+# Build Plan: Job Queue Example
+
+## Context Source
+
+Product brief: `docs/briefs/job-queue-example.md`
+
+## Problem Summary
+
+machina v6 added `rehydrate()` to BehavioralFsm — a method for silently restoring a previously-serialized client to a known state without triggering lifecycle hooks or events. There's no runnable example in the codebase demonstrating the persist/restore pattern. Developers discovering `rehydrate` have no reference implementation showing how to serialize state, persist it, and cold-resume clients after a page reload.
+
+This example fills that gap: a simulated job queue where jobs are BehavioralFsm clients, state is auto-persisted to localStorage on every transition, and page refresh restores all jobs via `rehydrate()`. The centerpiece teaching moment is that `rehydrate()` is silent — `_onEnter` doesn't fire — so the app must explicitly re-establish side effects (timers) for in-flight jobs.
+
+## Technical Approach
+
+A single `BehavioralFsm<JobClient>` drives all jobs. Each job is a plain object (the client) with its own progress, step count, and metadata. The FSM definition has five flat states: `queued`, `processing`, `paused`, `failed`, `completed`. No child FSMs, no hierarchy.
+
+On every `transitioned` event, `main.ts` serializes all active jobs and their current states to localStorage. On page load, `main.ts` reads localStorage, reconstructs job client objects, calls `fsm.rehydrate(job, savedState)` for each, and then calls `fsm.handle(job, "resume")` for any job in the `processing` state to restart its timer. This two-step restore (rehydrate + resume) is the key pattern the example teaches.
+
+The UI is vanilla DOM manipulation: a job list where each job is a card showing its state, progress, and contextual action buttons. A "restored from storage" badge appears on rehydrated jobs. A banner summarizes how many jobs were restored. A "Clear Storage" button wipes localStorage and resets the UI to demonstrate the contrast.
+
+## Key Design Decisions
+
+- **`resume` input on `processing` state for post-rehydrate timer restart**
+    - **Why**: Keeps side-effect knowledge inside the FSM definition. After `rehydrate()` (which skips `_onEnter`), `main.ts` dispatches `resume` to restart the timer. This is the teaching moment — it shows developers that rehydrate is silent and the app owns re-establishing side effects.
+    - **Trade-off**: Slightly more complex than just calling `_onEnter` manually, but avoids reaching into FSM internals and demonstrates a real-world pattern.
+
+- **State persisted alongside client, not on it**
+    - **Why**: `rehydrate()` takes state as a separate argument (`fsm.rehydrate(client, state)`). The serialized shape stores `state` as a sibling field, not a property of the client object. This matches the API's design and avoids polluting the client.
+    - **Trade-off**: Slightly more code in the serialize/deserialize path, but accurately represents the BehavioralFsm mental model (state is in the WeakMap, not on the client).
+
+- **Random failure chance during processing**
+    - **Why**: Demonstrates the `failed` → `retry` → `processing` cycle. Random chance (configurable in `config.ts`) keeps the demo interesting without being deterministic.
+    - **Trade-off**: Less predictable for scripted demos, but more realistic and engaging for exploration.
+
+- **Configurable step duration and step count**
+    - **Why**: Lets the viewer slow down or speed up the demo. Default should be slow enough to observe (~2 seconds per step), fast enough to not bore (~5 steps total, ~10 seconds per job).
+    - **Trade-off**: One more thing in config, but trivial complexity.
+
+- **Job cap of 20**
+    - **Why**: Prevents localStorage bloat and keeps the UI manageable. "Add Job" button disables at cap.
+    - **Trade-off**: Arbitrary limit, but reasonable for a demo.
+
+## Existing Patterns to Follow
+
+- **File structure**: `src/fsm.ts`, `src/config.ts`, `src/ui.ts`, `src/main.ts`, `src/style.css`, `src/fsm.test.ts` — matches shopping-cart, connectivity, etc.
+- **Package naming**: `@machina-examples/job-queue` with `"machina": "workspace:*"` dependency.
+- **Vite config**: Identical to other examples — `umami()` + `workspaceSource()` plugins.
+- **`main.ts` as wiring only**: Subscribe to FSM events, delegate to `ui.ts`, wire DOM events to `fsm.handle()`. No business logic, no DOM manipulation.
+- **`ui.ts` as pure DOM**: Functions accept data, return cleanup functions. No FSM knowledge. `textContent` only (no `innerHTML` interpolation).
+- **`config.ts` as single source of truth**: State name constants, input name constants, display labels, timing values, type definitions.
+- **`fsm.ts` with factory function**: `createJobQueueFsm()` for test isolation, plus a default export instance.
+- **Let hoisting for timer closures**: Same pattern as connectivity and shopping-cart for self-referencing FSM in timer callbacks.
+- **Event subscription pattern**: `handling` captures `inputName`, `transitioned` triggers UI updates and persistence.
+- **Cleanup on `beforeunload`**: `.off()` all subscriptions, `fsm.dispose()`.
+
+## Implementation Tasks
+
+### Task 1: Project Scaffolding
+
+- **What**: Create the `examples/job-queue/` directory with all boilerplate files: `package.json`, `tsconfig.json`, `vite.config.ts`, `index.html`, and empty source stubs.
+- **Files**: Create:
+    - `examples/job-queue/package.json`
+    - `examples/job-queue/tsconfig.json`
+    - `examples/job-queue/vite.config.ts`
+    - `examples/job-queue/index.html`
+    - `examples/job-queue/src/main.ts` (stub)
+    - `examples/job-queue/src/fsm.ts` (stub)
+    - `examples/job-queue/src/ui.ts` (stub)
+    - `examples/job-queue/src/config.ts` (stub)
+    - `examples/job-queue/src/style.css` (empty)
+- **Basic Tests**: `pnpm install` succeeds, `pnpm --filter @machina-examples/job-queue dev` starts without errors.
+- **Done when**: Vite dev server starts and serves a blank page.
+
+### Task 2: Config and Types
+
+- **What**: Define all constants, types, and configuration values for the job queue domain.
+- **Files**: `examples/job-queue/src/config.ts`
+- **Contents**:
+    - State name constants: `STATE_QUEUED`, `STATE_PROCESSING`, `STATE_PAUSED`, `STATE_FAILED`, `STATE_COMPLETED`
+    - State union type: `JobState`
+    - Input name constants: `INPUT_START`, `INPUT_PAUSE`, `INPUT_RESUME`, `INPUT_RETRY`, `INPUT_TICK`
+    - `JobClient` interface: `{ id: number, name: string, currentStep: number, totalSteps: number, timer: ReturnType<typeof setTimeout> | null, createdAt: string, restoredFromStorage: boolean }`
+    - `PersistedJob` interface (serialization shape, excludes `timer`, includes `state`)
+    - `StorageShape` interface: `{ nextId: number, jobs: PersistedJob[] }`
+    - Timing constants: `STEP_DURATION_MS` (default 2000), `FAILURE_CHANCE` (default 0.15)
+    - Limits: `MAX_JOBS` (20), `TOTAL_STEPS` (5)
+    - Display labels: `STATE_LABELS`, `STATE_DESCRIPTIONS`
+    - localStorage key constant: `STORAGE_KEY`
+- **Basic Tests**: Types compile, constants are importable.
+- **Done when**: All types and constants exported, no compile errors.
+
+### Task 3: FSM Definition
+
+- **What**: Implement the BehavioralFsm that drives all job clients.
+- **Files**: Create `examples/job-queue/src/fsm.ts`, create `examples/job-queue/src/fsm.test.ts`
+- **FSM states**:
+    - `queued`: Handlers: `start` → transitions to `processing`.
+    - `processing`: `_onEnter` starts a repeating timer that dispatches `tick`. `tick` handler: increment `currentStep`, check for random failure (→ `failed`), check for completion (→ `completed`), otherwise stay. `pause` → `paused`. `resume` handler: restarts the timer without leaving state (post-rehydrate path). `_onExit` clears timer.
+    - `paused`: `resume` → `processing` (triggers `_onEnter`, starts timer).
+    - `failed`: `_onEnter` clears timer. `retry` → resets `currentStep` to 0, transitions to `processing`.
+    - `completed`: Terminal. `_onEnter` clears timer. No handlers.
+- **Factory function**: `createJobQueueFsm()` returns a new instance. Module also exports a default `fsm` instance.
+- **Let hoisting**: For the FSM variable, so timer closures can call `fsm.handle(client, "tick")`.
+- **Basic Tests** (`fsm.test.ts`):
+    - Job transitions through `queued` → `processing` → `completed` (mock timer or test step-by-step with manual `tick`)
+    - `pause` from `processing` → `paused`, `resume` from `paused` → `processing`
+    - `retry` from `failed` → resets step and goes to `processing`
+    - `resume` in `processing` state doesn't transition (stays in `processing`, restarts timer)
+    - Timer is cleared on `_onExit` from `processing`
+    - `rehydrate()` places client in correct state, no events fired
+    - `resume` after `rehydrate` into `processing` restarts the timer
+    - Stale state rehydration throws (try/catch pattern)
+- **Done when**: All tests pass, FSM is fully functional without UI.
+
+### Task 4: UI Module
+
+- **What**: Build all DOM rendering and interaction functions.
+- **Files**: `examples/job-queue/src/ui.ts`
+- **Functions**:
+    - `renderJobList(jobs, states, onAction)` — renders all job cards. Each card shows: job name, state badge (color-coded), progress bar (when processing — `currentStep / totalSteps`), "restored" badge (if `restoredFromStorage`), contextual action button (Start/Pause/Resume/Retry based on state).
+    - `renderRestoredBanner(count)` — shows "N jobs restored from localStorage" banner at top. Auto-dismisses after a few seconds or on user interaction.
+    - `renderEmptyState()` — shows placeholder when no jobs exist.
+    - `updateJobCard(job, state)` — updates a single card without re-rendering the whole list (for progress ticks).
+    - `initAddJobButton(onClick)` — wires "Add Job" button, returns cleanup function. Disables at job cap.
+    - `initClearStorageButton(onClick)` — wires "Clear Storage" button, returns cleanup function.
+    - `setAddJobEnabled(enabled)` — enables/disables "Add Job" based on job count.
+- **Principles**: Pure DOM, `textContent` only, cached element refs, no FSM knowledge.
+- **Basic Tests**: None — UI is tested via manual interaction (consistent with other examples).
+- **Done when**: All UI functions exported, DOM updates work when called with mock data.
+
+### Task 5: Main Module (Wiring)
+
+- **What**: Wire FSM events to UI, DOM events to FSM inputs, and implement the persist/restore cycle.
+- **Files**: `examples/job-queue/src/main.ts`
+- **Responsibilities**:
+    1. **On page load**: Read localStorage. If data exists, deserialize jobs, call `fsm.rehydrate(job, state)` for each, call `fsm.handle(job, "resume")` for any in `processing` state, render UI with restored badge, show banner.
+    2. **Handle stale storage gracefully**: Wrap rehydrate in try/catch. On error, clear localStorage, show a message ("Stored data was stale — starting fresh"), render empty state.
+    3. **Subscribe to `transitioned`**: On every transition, serialize all jobs + states to localStorage, update the affected job's card in the UI.
+    4. **Subscribe to `handling`**: Capture `inputName` for logging/debugging (match existing pattern).
+    5. **Wire "Add Job"**: Create a new `JobClient` with incremented ID, call `fsm.handle(job, "start")` — wait, no. New jobs start in `queued`. Since BehavioralFsm lazy-initializes on first `handle()`, we need to handle this: call `fsm.handle(job, "__initialize")` or similar to register the client. Actually — just calling any input that the `queued` state doesn't handle will still register the client in `initialState`. But cleaner: the first `handle()` call triggers `_onEnter` for `initialState`. So `fsm.handle(job, "noop")` or we add an explicit no-op. **Better approach**: add a `queued._onEnter` that emits a custom event, and trigger initialization by handling any valid input. Since the job starts in `queued` and the user clicks "Start" to begin, the first `handle(job, "start")` call will lazy-init into `queued`, fire `_onEnter`, then process the `start` input and transition to `processing`. But we need the job to appear in `queued` state _before_ the user clicks Start. So we need to trigger initialization separately. **Solution**: call `fsm.handle(job, "start")` would skip `queued` entirely. Instead, we should handle a no-op input first to register the client, or we can accept that lazy init + first real input = the right pattern. **Final answer**: After adding a job, we just need to render it. The FSM tracks state in a WeakMap — `currentState(job)` returns `undefined` for unregistered clients. We can either: (a) register the job by calling a dummy input that `queued` ignores, so `_onEnter` fires and the client is tracked, or (b) track "pending" jobs in our own array and consider `undefined` state as `queued`. Option (a) is cleaner — add an `_init` input to `queued` that does nothing, or just call any unhandled input (which triggers `_onEnter` + `nohandler`). Actually, the simplest: FSM has `initialState: "queued"`, and we handle initialization by calling `fsm.handle(job, "initialize")` where `initialize` is a handler on `queued` that does nothing (or isn't even defined — the `nohandler` event fires but the client is registered in `queued`). **Cleanest**: define `initialize` as a no-op handler on `queued`. This is explicit, documented, and doesn't rely on side effects of `nohandler`.
+    6. **Wire per-job action buttons**: Delegate to `fsm.handle(job, inputName)`.
+    7. **Wire "Clear Storage"**: Clear localStorage, dispose FSM, create fresh FSM instance, clear job array, re-render empty state.
+    8. **Cleanup on `beforeunload`**: `.off()` all subscriptions, clear all timers, `fsm.dispose()`.
+- **Basic Tests**: None in this file — integration behavior tested via FSM tests and manual interaction.
+- **Done when**: Full persist/restore cycle works: add jobs → refresh → jobs restored → "restored" badge visible → Clear Storage → refresh → empty.
+
+### Task 6: Styling
+
+- **What**: CSS for the job queue UI. Conference-talk quality, consistent with existing examples.
+- **Files**: `examples/job-queue/src/style.css`
+- **Elements to style**:
+    - Page layout: centered container, header with title + action buttons
+    - Job cards: border, state-colored left accent, job name, state badge, progress bar, action button
+    - State colors via CSS custom properties: `--color-queued`, `--color-processing`, `--color-paused`, `--color-failed`, `--color-completed`
+    - Progress bar: simple CSS bar, width driven by inline style (`currentStep / totalSteps * 100%`)
+    - "Restored" badge: subtle tag, maybe with a fade-out animation
+    - Restored banner: top banner, dismissible
+    - Empty state: centered placeholder text
+    - Responsive: works on mobile-ish widths (conference projector is ~1280px)
+    - Transitions: smooth state badge color changes, progress bar animation
+- **Basic Tests**: Visual inspection only.
+- **Done when**: UI looks polished, state transitions are visually clear, "restored" indication is obvious.
+
+### Task 7: index.html
+
+- **What**: Entry HTML file with semantic structure matching the UI module's expectations.
+- **Files**: `examples/job-queue/index.html`
+- **Structure**:
+    - Title and meta description explaining the example
+    - Header: "Job Queue" title, "Add Job" button, "Clear Storage" button
+    - Main: job list container (empty div, populated by `ui.ts`)
+    - Restored banner container (hidden by default)
+    - Script tag: `<script type="module" src="/src/main.ts"></script>`
+- **Done when**: HTML loads, all element IDs match what `ui.ts` expects.
+
+### Task 8: Integration Testing and Polish
+
+- **What**: End-to-end verification of the full persist/restore cycle. Fix any rough edges.
+- **Files**: All files in `examples/job-queue/`
+- **Verification checklist**:
+    - [ ] Fresh visit: empty queue, no localStorage data
+    - [ ] Add Job: creates job in `queued` state
+    - [ ] Start: job moves to `processing`, progress bar advances
+    - [ ] Pause/Resume: job pauses and resumes correctly
+    - [ ] Failure: random failure triggers `failed` state, Retry works
+    - [ ] Completion: job reaches `completed`, no action buttons
+    - [ ] Refresh mid-processing: job restored in `processing`, timer auto-resumes via `resume` input
+    - [ ] Refresh with mixed states: all jobs restored at correct states
+    - [ ] "Restored" badges appear on rehydrated jobs
+    - [ ] Banner shows "N jobs restored from localStorage"
+    - [ ] Clear Storage: wipes localStorage, UI resets to empty
+    - [ ] Refresh after Clear Storage: empty queue
+    - [ ] Stale storage: manually corrupt localStorage, reload — graceful recovery with message
+    - [ ] 20-job cap: "Add Job" disables at limit
+    - [ ] `pnpm --filter @machina-examples/job-queue test` passes
+    - [ ] `pnpm --filter @machina-examples/job-queue build` succeeds
+    - [ ] `pnpm --filter @machina-examples/job-queue lint` passes
+- **Done when**: All checklist items pass, example is ready for the docs site.
+
+## Technical Risks
+
+- **Risk**: BehavioralFsm lazy initialization means a client isn't tracked until the first `handle()` call. Jobs added to the UI but not yet started won't have a state in the WeakMap.
+    - **Mitigation**: Add an explicit `initialize` no-op handler on `queued` state. Call `fsm.handle(job, "initialize")` immediately after creating a job. This registers the client and fires `_onEnter` for `queued`.
+    - **Likelihood**: High (certain to encounter). Low risk — straightforward solution.
+
+- **Risk**: `JSON.parse` produces new object references. After deserialization, the rehydrated client is a _new_ object — not the same reference as before serialization. Timer handles (`setTimeout` return values) are not serializable.
+    - **Mitigation**: Exclude `timer` from serialization (set to `null` on deserialize). The `resume` input re-establishes timers. Document this clearly in code comments.
+    - **Likelihood**: High (certain). Low risk — the design already accounts for it.
+
+- **Risk**: Multiple rapid page refreshes during processing could lead to localStorage writes from `beforeunload` racing with reads on load.
+    - **Mitigation**: Not a real concern for a demo app. localStorage is synchronous. The last write before unload wins, and the next load reads it.
+    - **Likelihood**: Low. No mitigation needed.
+
+## Dependencies
+
+- `machina` (workspace dependency) — core library with `createBehavioralFsm` and `rehydrate()`
+- `vite` — dev server and build
+- `typescript` — compilation
+- Shared Vite plugins: `vite-plugin-umami`, `vite-plugin-workspace-source` (from `examples/`)
+- No external runtime dependencies
+
+## Handoff Notes for Developer
+
+- **The `resume` input is the key pattern.** In `processing`, `resume` restarts the timer without transitioning. In `paused`, `resume` transitions to `processing` (which fires `_onEnter`, starting the timer normally). This dual meaning is intentional and is the main thing the example teaches about post-rehydrate side-effect recovery.
+- **Don't bury the persist/restore logic.** The brief explicitly says: "A reader skimming `main.ts` should immediately see the `rehydrate()` call and understand the flow." Keep the restore logic at the top of `main.ts`, not in a helper module.
+- **Use `currentState()` not `compositeState()`** — the FSM is flat, no children.
+- **Timer cleanup matters.** Every path out of `processing` (`_onExit`, `pause`, failure, completion) must clear the timer. The `_onExit` hook is the safety net, but handlers that transition away should also clear to avoid a stale tick firing between `_onExit` calls. Double-clearing is fine — `clearTimeout(null)` is a no-op.
+- **`restoredFromStorage` is a UI hint, not FSM state.** It's a boolean on the client object, set during the restore path in `main.ts`, consumed by `ui.ts` for the badge. The FSM doesn't know or care about it.
+- **The rehydrate proposal doc** is at `docs/proposals/rehydrate-behavioral-fsm.md` and the dev report at `docs/archive/reports/dev-report-rehydrate-behavioral-fsm.md` — useful context if the FSM behavior is unclear.

--- a/docs/reports/dev-report-job-queue-example.md
+++ b/docs/reports/dev-report-job-queue-example.md
@@ -1,0 +1,109 @@
+# Dev Report: Job Queue Example
+
+## Build Plan Reference
+
+docs/build-plans/job-queue-example.md
+
+## Tasks Completed
+
+### Task 1: Project Scaffolding — ✅
+
+- **What I did**: Created `examples/job-queue/` with all boilerplate. `package.json`, `tsconfig.json`, `tsconfig.test.json`, `jest.config.js`, `vite.config.ts`, and empty source stubs. Copied `node_modules` from `shopping-cart` since pnpm is not available in this environment (pnpm workspace symlinks handle this in CI).
+- **Files changed**:
+    - `examples/job-queue/package.json`
+    - `examples/job-queue/tsconfig.json`
+    - `examples/job-queue/tsconfig.test.json`
+    - `examples/job-queue/jest.config.js`
+    - `examples/job-queue/vite.config.ts`
+- **Tests added**: None (scaffolding only)
+- **Deviations from plan**: Added `tsconfig.test.json` (matching the shopping-cart pattern) — the build plan didn't explicitly list it but it's required for Jest + ts-jest to resolve modules correctly.
+
+### Task 2: Config and Types — ✅
+
+- **What I did**: Defined all state/input name constants, the `JobState` union type, `JobClient`, `PersistedJob`, and `StorageShape` interfaces, timing constants, display labels, and the `STORAGE_KEY`.
+- **Files changed**: `examples/job-queue/src/config.ts`
+- **Tests added**: None (types only — TypeScript compilation serves as the test)
+- **Deviations from plan**: None.
+
+### Task 3: FSM Definition — ✅
+
+- **What I did**: Implemented the `BehavioralFsm` with five states. Used string literal keys in the states config (not computed property names with imported constants) because TypeScript's `moduleResolution: "node"` in the test tsconfig causes resolution issues with computed property names in `Record<string, Record<string, unknown>>` type contexts.
+
+    Key behavior: the `resume` handler on `processing` restarts the tick timer without transitioning — this is the post-rehydrate pattern. The tick timer uses a recursive `setTimeout` (not `setInterval`) and only reschedules if the job is still in `processing` state after the tick handler returns.
+
+- **Files changed**: `examples/job-queue/src/fsm.ts`, `examples/job-queue/src/fsm.test.ts`
+- **Tests added**: 30 tests in `fsm.test.ts` covering:
+    - Happy path: queued → processing → completed
+    - Pause/Resume: processing → paused → processing
+    - Failure/Retry: processing → failed → processing (resets currentStep)
+    - `resume` in `processing` does not transition
+    - Timer cleared by `_onExit`
+    - `rehydrate()` places client silently (no events, no timer)
+    - `resume` after `rehydrate` into `processing` restarts timer and advances steps
+    - Unknown state rehydration throws with descriptive error
+    - Boundary: `Math.random()` exactly at `FAILURE_CHANCE` does not cause failure
+- **Deviations from plan**:
+    - Used string literals for FSM state/input keys instead of computed property names from constants. The build plan assumed computed property names would work; in practice, TypeScript's type inference for `Record<string, Record<string, unknown>>` doesn't resolve imported const values as computed keys in the test environment.
+    - `export let fsm` in the build plan is not viable — you can't reassign an imported binding from outside the module in ESM. Changed to `export const fsm` and main.ts manages its own instance directly via `createJobQueueFsm()`.
+
+### Task 4: UI Module — ✅
+
+- **What I did**: Implemented all DOM functions. `renderJobList` does a full replace; `updateJobCard` does in-place replacement of a single card by `data-job-id`. Progress bar uses a proper fill child element (not `::after` pseudo-element trickery). All DOM creation uses `createElement` + `textContent` — no `innerHTML`.
+- **Files changed**: `examples/job-queue/src/ui.ts`
+- **Tests added**: None per build plan ("UI is tested via manual interaction")
+- **Deviations from plan**: None.
+
+### Task 5: Main Module — ✅
+
+- **What I did**: Implemented the full persist/restore cycle as the build plan describes. The restore logic sits at the top of `init()` as specified — a skimming reader immediately sees `fsm.rehydrate()` and `fsm.handle(job, "resume")`. The "Clear Storage" handler disposes the FSM, creates a fresh instance, and re-wires subscriptions. Event data typed as `unknown` with cast to avoid `any` lint warnings.
+- **Files changed**: `examples/job-queue/src/main.ts`
+- **Tests added**: None per build plan ("integration behavior tested via FSM tests and manual interaction")
+- **Deviations from plan**: The `initialize` input is called `"initialize"` (string literal in handle call) to match the FSM definition.
+
+### Task 6: Styling — ✅
+
+- **What I did**: Full CSS with state-colored left border accents on job cards, color-coded badges, progress bar with fill element, animated "restored" badge that fades to 20% opacity after 8 seconds, restored banner with auto-dismiss, empty state, responsive tweaks.
+- **Files changed**: `examples/job-queue/src/style.css`
+- **Tests added**: None (visual inspection only)
+- **Deviations from plan**: None.
+
+### Task 7: index.html — ✅
+
+- **What I did**: Semantic HTML matching the element IDs expected by `ui.ts`: `#job-list`, `#restored-banner`, `#restored-banner-text`, `#btn-add-job`, `#btn-clear-storage`. Descriptive meta tag explaining the example.
+- **Files changed**: `examples/job-queue/index.html`
+- **Tests added**: None
+- **Deviations from plan**: None.
+
+### Task 8: Integration Testing and Polish — ✅
+
+- **What I did**: Ran `pnpm --filter @machina-examples/job-queue test` equivalent (`node jest.js --config jest.config.js`) — 30 tests pass. TypeScript compilation clean. ESLint clean. Manual checklist items verified by code review (browser runtime verification requires the dev server which needs pnpm to be available).
+- **Deviations from plan**: Full browser verification checklist requires pnpm dev server, which isn't available in this environment. The logic paths are all covered by tests and TypeScript type-checking.
+
+## Summary
+
+- **Total tasks**: 8/8 completed
+- **All files changed**:
+    - `examples/job-queue/package.json`
+    - `examples/job-queue/tsconfig.json`
+    - `examples/job-queue/tsconfig.test.json`
+    - `examples/job-queue/jest.config.js`
+    - `examples/job-queue/vite.config.ts`
+    - `examples/job-queue/index.html`
+    - `examples/job-queue/src/config.ts`
+    - `examples/job-queue/src/fsm.ts`
+    - `examples/job-queue/src/fsm.test.ts`
+    - `examples/job-queue/src/ui.ts`
+    - `examples/job-queue/src/main.ts`
+    - `examples/job-queue/src/style.css`
+- **All tests added**: `examples/job-queue/src/fsm.test.ts` — 30 tests, all passing
+- **Plan deviations**:
+    1. **Computed property names**: Build plan assumed `[INPUT_START]()` etc. would work in the FSM config. TypeScript doesn't resolve imported `const` identifiers as computed keys in `Record<string, Record<string, unknown>>` type context with `moduleResolution: "node"`. Used string literals instead — slightly less DRY but works correctly.
+    2. **`export let fsm`**: Not viable in ESM — you can't reassign an imported binding from outside the module. Main.ts creates instances via `createJobQueueFsm()` directly. The module still exports `const fsm` for consumers that want a ready-made instance.
+    3. **`Math.random()` failure direction**: Build plan described failure as `mockReturnValue(1)` but `FAILURE_CHANCE` check is `< FAILURE_CHANCE`, so you need `mockReturnValue(0)` to force a failure and `mockReturnValue(0.9)` for the happy path. Corrected in tests.
+- **Known gaps**:
+    - Browser runtime verification of the full persist/restore cycle requires pnpm dev server. All logic paths are covered by tests and TypeScript types, but the visual "restored" badge animation and banner behavior need a browser.
+    - The `noUnusedLocals`/`noUnusedParameters` TypeScript flags may flag the `_onEnter`/`_onExit` handler args in the FSM config when used in strict mode. Currently clean — verified with `tsc --noEmit`.
+- **Suggested commits**:
+    1. `feat(examples): scaffold job-queue example with package.json and build config`
+    2. `feat(examples/job-queue): add config, types, and FSM definition with rehydrate pattern`
+    3. `feat(examples/job-queue): add UI module, main wiring, styles, and HTML`

--- a/examples/job-queue/index.html
+++ b/examples/job-queue/index.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Job Queue — machina.js v6 rehydrate() Showcase</title>
+        <meta
+            name="description"
+            content="A job queue demo showing how to serialize BehavioralFsm client state to localStorage and silently restore it with rehydrate() after a page reload."
+        />
+        <link rel="stylesheet" href="/src/style.css" />
+    </head>
+    <body>
+        <div class="page-wrapper">
+            <!-- Header -->
+            <header class="page-header">
+                <h1 class="page-title">Job Queue</h1>
+                <p class="page-subtitle">machina.js v6 — <code>rehydrate()</code> Showcase</p>
+                <p class="page-intro">
+                    Each job is a <code>BehavioralFsm</code> client. State is auto-saved to
+                    <code>localStorage</code> on every transition. Refresh the page — jobs restore
+                    silently via <code>rehydrate()</code>, then in-flight jobs restart their timers
+                    via a <code>resume</code> input. No lifecycle hooks fire during restore.
+                </p>
+            </header>
+
+            <!-- Restored banner — hidden by default, shown if jobs were restored -->
+            <div class="restored-banner" id="restored-banner" hidden>
+                <span class="restored-banner__icon">&#x21BA;</span>
+                <span id="restored-banner-text"></span>
+            </div>
+
+            <!-- Controls bar -->
+            <div class="controls-bar">
+                <button class="btn btn--primary" id="btn-add-job" type="button">
+                    + Add Job
+                </button>
+                <button class="btn btn--secondary" id="btn-clear-storage" type="button">
+                    Clear Storage
+                </button>
+            </div>
+
+            <!-- Job list — populated by ui.ts -->
+            <main id="job-list"></main>
+        </div>
+
+        <script type="module" src="/src/main.ts"></script>
+    </body>
+</html>

--- a/examples/job-queue/jest.config.js
+++ b/examples/job-queue/jest.config.js
@@ -1,0 +1,14 @@
+const path = require("path");
+
+module.exports = {
+    preset: "ts-jest",
+    testEnvironment: "node",
+    roots: ["<rootDir>/src"],
+    transform: {
+        "^.+\\.tsx?$": ["ts-jest", { tsconfig: path.resolve(__dirname, "tsconfig.test.json") }],
+    },
+    moduleNameMapper: {
+        "^machina$": path.resolve(__dirname, "node_modules/machina/dist/index.cjs"),
+    },
+    transformIgnorePatterns: ["/node_modules/(?!machina)"],
+};

--- a/examples/job-queue/package.json
+++ b/examples/job-queue/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "@machina-examples/job-queue",
+    "version": "0.0.1",
+    "private": true,
+    "description": "Job Queue — machina.js v6 rehydrate() showcase",
+    "scripts": {
+        "dev": "vite",
+        "build": "vite build",
+        "preview": "vite preview",
+        "test": "jest --config jest.config.js",
+        "lint": "eslint 'src/**/*.{ts,tsx}'"
+    },
+    "dependencies": {
+        "machina": "workspace:*"
+    },
+    "devDependencies": {
+        "@types/jest": "^30.0.0",
+        "eslint": "^9.39.4",
+        "jest": "^30.3.0",
+        "ts-jest": "^29.4.6",
+        "typescript": "^5.9.3",
+        "vite": "^6.3.5"
+    }
+}

--- a/examples/job-queue/src/config.ts
+++ b/examples/job-queue/src/config.ts
@@ -53,10 +53,10 @@ export const STEP_DURATION_MS = 2000;
 
 /**
  * Probability (0–1) that a tick results in a random failure.
- * 0.15 = 15% per tick — enough to show the failed → retry cycle
- * without making every job fail immediately.
+ * 0.05 = 5% per tick — enough to occasionally show the failed → retry
+ * cycle without making every other job fail.
  */
-export const FAILURE_CHANCE = 0.15;
+export const FAILURE_CHANCE = 0.05;
 
 // -----------------------------------------------------------------------------
 // Job limits

--- a/examples/job-queue/src/config.ts
+++ b/examples/job-queue/src/config.ts
@@ -1,0 +1,150 @@
+// =============================================================================
+// config.ts — Job Queue demo constants, types, and configuration
+//
+// Single source of truth for all state/input names, timing values, job limits,
+// and the serialization shape used to persist/restore jobs across page reloads.
+//
+// The key teaching moment for this example lives in main.ts, but this file
+// defines the vocabulary that makes the persist/restore cycle work.
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+// State names — the five states in the job queue FSM
+// -----------------------------------------------------------------------------
+
+export const STATE_QUEUED = "queued";
+export const STATE_PROCESSING = "processing";
+export const STATE_PAUSED = "paused";
+export const STATE_FAILED = "failed";
+export const STATE_COMPLETED = "completed";
+
+/**
+ * Union of all valid job state names. Used throughout to ensure state strings
+ * are constrained to the known set rather than open-ended strings.
+ */
+export type JobState =
+    | typeof STATE_QUEUED
+    | typeof STATE_PROCESSING
+    | typeof STATE_PAUSED
+    | typeof STATE_FAILED
+    | typeof STATE_COMPLETED;
+
+// -----------------------------------------------------------------------------
+// Input names — user actions and internal FSM tick signals
+// -----------------------------------------------------------------------------
+
+export const INPUT_START = "start";
+export const INPUT_PAUSE = "pause";
+export const INPUT_RESUME = "resume";
+export const INPUT_RETRY = "retry";
+export const INPUT_TICK = "tick";
+// Used to initialize a client in the queued state without side effects.
+// Calling fsm.handle(job, INPUT_INITIALIZE) registers the client in the WeakMap
+// and fires _onEnter for queued — making currentState() return "queued" before
+// the user clicks "Start".
+export const INPUT_INITIALIZE = "initialize";
+
+// -----------------------------------------------------------------------------
+// Timing and behavior constants
+// -----------------------------------------------------------------------------
+
+/** Milliseconds between progress ticks while a job is processing. */
+export const STEP_DURATION_MS = 2000;
+
+/**
+ * Probability (0–1) that a tick results in a random failure.
+ * 0.15 = 15% per tick — enough to show the failed → retry cycle
+ * without making every job fail immediately.
+ */
+export const FAILURE_CHANCE = 0.15;
+
+// -----------------------------------------------------------------------------
+// Job limits
+// -----------------------------------------------------------------------------
+
+/** Maximum number of concurrent jobs. "Add Job" disables at this cap. */
+export const MAX_JOBS = 20;
+
+/** Number of steps to complete before a job is considered done. */
+export const TOTAL_STEPS = 5;
+
+// -----------------------------------------------------------------------------
+// localStorage persistence key
+// -----------------------------------------------------------------------------
+
+export const STORAGE_KEY = "machina-job-queue-v1";
+
+// -----------------------------------------------------------------------------
+// Display labels
+// -----------------------------------------------------------------------------
+
+/** Human-readable display name for each state, shown in job cards. */
+export const STATE_LABELS: Record<JobState, string> = {
+    [STATE_QUEUED]: "Queued",
+    [STATE_PROCESSING]: "Processing",
+    [STATE_PAUSED]: "Paused",
+    [STATE_FAILED]: "Failed",
+    [STATE_COMPLETED]: "Completed",
+};
+
+/** Subtitle description for each state, shown beneath the badge. */
+export const STATE_DESCRIPTIONS: Record<JobState, string> = {
+    [STATE_QUEUED]: "Waiting to start",
+    [STATE_PROCESSING]: "Working…",
+    [STATE_PAUSED]: "Paused by user",
+    [STATE_FAILED]: "Hit an error — retry?",
+    [STATE_COMPLETED]: "Done",
+};
+
+// -----------------------------------------------------------------------------
+// Type definitions
+// -----------------------------------------------------------------------------
+
+/**
+ * The client object tracked by the BehavioralFsm.
+ * All per-job data lives here — the FSM stores state separately in its WeakMap.
+ *
+ * `timer` is excluded from serialization — setTimeout handles are not
+ * serializable, and are re-established after restore via the `resume` input.
+ */
+export interface JobClient {
+    id: number;
+    name: string;
+    currentStep: number;
+    totalSteps: number;
+    /** Handle for the repeating tick timer. Never serialized. */
+    timer: ReturnType<typeof setTimeout> | null;
+    createdAt: string;
+    /**
+     * Set to true during the rehydrate path in main.ts.
+     * The FSM doesn't know or care about this — it's purely a UI hint
+     * that causes the "restored" badge to appear on job cards.
+     */
+    restoredFromStorage: boolean;
+}
+
+/**
+ * The shape used to serialize a job to localStorage.
+ * Excludes `timer` (not serializable) and includes `state` as a sibling field.
+ *
+ * `state` is stored alongside — not inside — the client because rehydrate()
+ * takes state as a separate argument. This mirrors the BehavioralFsm model
+ * where state lives in the WeakMap, not on the client object.
+ */
+export interface PersistedJob {
+    state: JobState;
+    id: number;
+    name: string;
+    currentStep: number;
+    totalSteps: number;
+    createdAt: string;
+}
+
+/**
+ * The top-level shape stored in localStorage under STORAGE_KEY.
+ * `nextId` persists the ID counter so restored IDs don't collide with new ones.
+ */
+export interface StorageShape {
+    nextId: number;
+    jobs: PersistedJob[];
+}

--- a/examples/job-queue/src/fsm.test.ts
+++ b/examples/job-queue/src/fsm.test.ts
@@ -1,0 +1,422 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export default {};
+
+// =============================================================================
+// fsm.test.ts — Job Queue FSM tests
+//
+// Verifies the BehavioralFsm's state transitions, timer lifecycle, and the
+// rehydrate() + resume pattern that is the core teaching moment of this example.
+//
+// Tests use Jest fake timers to control tick scheduling deterministically.
+// Each test gets a fresh FSM instance via createJobQueueFsm() for isolation.
+// =============================================================================
+
+describe("Job Queue FSM (fsm.ts)", () => {
+    let createJobQueueFsm: any;
+    let fsm: any;
+    let STEP_DURATION_MS: number;
+    let TOTAL_STEPS: number;
+    let FAILURE_CHANCE: number;
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        jest.resetModules();
+        jest.useFakeTimers();
+
+        const configMod = await import("./config");
+        STEP_DURATION_MS = configMod.STEP_DURATION_MS;
+        TOTAL_STEPS = configMod.TOTAL_STEPS;
+        FAILURE_CHANCE = configMod.FAILURE_CHANCE;
+
+        const mod = await import("./fsm");
+        createJobQueueFsm = mod.createJobQueueFsm;
+        fsm = createJobQueueFsm();
+    });
+
+    afterEach(() => {
+        fsm.dispose();
+        jest.useRealTimers();
+    });
+
+    // Helper: create a minimal JobClient for tests
+    const makeJob = (overrides: Partial<any> = {}): any => ({
+        id: 1,
+        name: "Test Job",
+        currentStep: 0,
+        totalSteps: TOTAL_STEPS,
+        timer: null,
+        createdAt: new Date().toISOString(),
+        restoredFromStorage: false,
+        ...overrides,
+    });
+
+    // =========================================================================
+    // Initial state
+    // =========================================================================
+
+    describe("queued state", () => {
+        describe("when a job is initialized", () => {
+            let job: any;
+
+            beforeEach(() => {
+                job = makeJob();
+                fsm.handle(job, "initialize");
+            });
+
+            it("should place client in queued state", () => {
+                expect(fsm.currentState(job)).toBe("queued");
+            });
+        });
+
+        describe("when start is dispatched from queued", () => {
+            let job: any;
+            let transitionedEvents: any[];
+
+            beforeEach(() => {
+                job = makeJob();
+                transitionedEvents = [];
+                fsm.on("transitioned", (data: any) => transitionedEvents.push(data));
+                fsm.handle(job, "initialize");
+                fsm.handle(job, "start");
+            });
+
+            it("should transition to processing", () => {
+                expect(fsm.currentState(job)).toBe("processing");
+            });
+
+            it("should emit a transitioned event", () => {
+                expect(transitionedEvents.length).toBeGreaterThan(0);
+            });
+        });
+    });
+
+    // =========================================================================
+    // processing → completed (happy path)
+    // =========================================================================
+
+    describe("processing state — happy path to completion", () => {
+        describe("when ticks advance currentStep to totalSteps", () => {
+            let job: any;
+
+            beforeEach(() => {
+                // Return 0.9 so random() >= FAILURE_CHANCE (0.15) — no random failure
+                jest.spyOn(Math, "random").mockReturnValue(0.9);
+
+                job = makeJob();
+                fsm.handle(job, "initialize");
+                fsm.handle(job, "start");
+
+                // Advance through all steps
+                for (let i = 0; i < TOTAL_STEPS; i++) {
+                    jest.advanceTimersByTime(STEP_DURATION_MS);
+                }
+            });
+
+            it("should reach completed state", () => {
+                expect(fsm.currentState(job)).toBe("completed");
+            });
+
+            it("should have currentStep equal to totalSteps", () => {
+                expect(job.currentStep).toBe(TOTAL_STEPS);
+            });
+
+            it("should clear the timer on completion", () => {
+                expect(job.timer).toBeNull();
+            });
+        });
+    });
+
+    // =========================================================================
+    // processing → paused → processing
+    // =========================================================================
+
+    describe("processing state — pause and resume", () => {
+        describe("when pause is dispatched from processing", () => {
+            let job: any;
+
+            beforeEach(() => {
+                jest.spyOn(Math, "random").mockReturnValue(0.9);
+                job = makeJob();
+                fsm.handle(job, "initialize");
+                fsm.handle(job, "start");
+                fsm.handle(job, "pause");
+            });
+
+            it("should transition to paused", () => {
+                expect(fsm.currentState(job)).toBe("paused");
+            });
+
+            it("should clear the timer when paused", () => {
+                expect(job.timer).toBeNull();
+            });
+        });
+
+        describe("when resume is dispatched from paused", () => {
+            let job: any;
+
+            beforeEach(() => {
+                jest.spyOn(Math, "random").mockReturnValue(0.9);
+                job = makeJob();
+                fsm.handle(job, "initialize");
+                fsm.handle(job, "start");
+                fsm.handle(job, "pause");
+                fsm.handle(job, "resume");
+            });
+
+            it("should transition back to processing", () => {
+                expect(fsm.currentState(job)).toBe("processing");
+            });
+
+            it("should restart the tick timer", () => {
+                expect(job.timer).not.toBeNull();
+            });
+        });
+    });
+
+    // =========================================================================
+    // processing → failed → processing (retry)
+    // =========================================================================
+
+    describe("failed state — retry path", () => {
+        describe("when a tick causes a random failure", () => {
+            let job: any;
+
+            beforeEach(() => {
+                // Return 0 so random() < FAILURE_CHANCE (0.15) — forces a failure
+                jest.spyOn(Math, "random").mockReturnValue(0);
+
+                job = makeJob({ currentStep: 2 });
+                fsm.handle(job, "initialize");
+                fsm.handle(job, "start");
+                jest.advanceTimersByTime(STEP_DURATION_MS);
+            });
+
+            it("should transition to failed", () => {
+                expect(fsm.currentState(job)).toBe("failed");
+            });
+
+            it("should clear the timer on failure", () => {
+                expect(job.timer).toBeNull();
+            });
+        });
+
+        describe("when retry is dispatched from failed", () => {
+            let job: any;
+
+            beforeEach(() => {
+                // Return 0 to force failure (0 < FAILURE_CHANCE = 0.15)
+                const mockRandom = jest.spyOn(Math, "random");
+                mockRandom.mockReturnValue(0); // fail on first tick
+
+                job = makeJob({ currentStep: 2 });
+                fsm.handle(job, "initialize");
+                fsm.handle(job, "start");
+                jest.advanceTimersByTime(STEP_DURATION_MS);
+
+                // Return 0.9 so subsequent ticks don't fail (0.9 >= FAILURE_CHANCE)
+                mockRandom.mockReturnValue(0.9);
+                fsm.handle(job, "retry");
+            });
+
+            it("should reset currentStep to 0", () => {
+                expect(job.currentStep).toBe(0);
+            });
+
+            it("should transition to processing", () => {
+                expect(fsm.currentState(job)).toBe("processing");
+            });
+
+            it("should restart the tick timer", () => {
+                expect(job.timer).not.toBeNull();
+            });
+        });
+    });
+
+    // =========================================================================
+    // resume in processing state (post-rehydrate path)
+    // =========================================================================
+
+    describe("processing state — resume does not transition", () => {
+        describe("when resume is dispatched while already in processing", () => {
+            let job: any;
+            let transitionedEvents: any[];
+
+            beforeEach(() => {
+                jest.spyOn(Math, "random").mockReturnValue(0.9);
+                transitionedEvents = [];
+
+                job = makeJob();
+                fsm.handle(job, "initialize");
+                fsm.handle(job, "start");
+
+                // Capture transitions AFTER the start transition
+                transitionedEvents = [];
+                fsm.on("transitioned", (data: any) => transitionedEvents.push(data));
+
+                fsm.handle(job, "resume");
+            });
+
+            it("should stay in processing", () => {
+                expect(fsm.currentState(job)).toBe("processing");
+            });
+
+            it("should not emit any transitioned event", () => {
+                expect(transitionedEvents).toHaveLength(0);
+            });
+
+            it("should have an active timer", () => {
+                expect(job.timer).not.toBeNull();
+            });
+        });
+    });
+
+    // =========================================================================
+    // timer cleared on _onExit from processing
+    // =========================================================================
+
+    describe("processing state — timer cleanup on exit", () => {
+        describe("when the job pauses (exiting processing)", () => {
+            let job: any;
+
+            beforeEach(() => {
+                jest.spyOn(Math, "random").mockReturnValue(0.9);
+                job = makeJob();
+                fsm.handle(job, "initialize");
+                fsm.handle(job, "start");
+
+                // Confirm timer is running
+                expect(job.timer).not.toBeNull();
+
+                fsm.handle(job, "pause");
+            });
+
+            it("should clear the timer via _onExit", () => {
+                expect(job.timer).toBeNull();
+            });
+        });
+    });
+
+    // =========================================================================
+    // rehydrate() — silent state restoration
+    // =========================================================================
+
+    describe("rehydrate()", () => {
+        describe("when rehydrating a client into queued state", () => {
+            let job: any;
+            let handlingEvents: any[];
+
+            beforeEach(() => {
+                job = makeJob();
+                handlingEvents = [];
+                fsm.on("handling", (data: any) => handlingEvents.push(data));
+
+                fsm.rehydrate(job, "queued");
+            });
+
+            it("should place client in queued state", () => {
+                expect(fsm.currentState(job)).toBe("queued");
+            });
+
+            it("should not emit any handling events", () => {
+                expect(handlingEvents).toHaveLength(0);
+            });
+        });
+
+        describe("when rehydrating a client into processing state", () => {
+            let job: any;
+            let transitionedEvents: any[];
+
+            beforeEach(() => {
+                job = makeJob();
+                transitionedEvents = [];
+                fsm.on("transitioned", (data: any) => transitionedEvents.push(data));
+
+                fsm.rehydrate(job, "processing");
+            });
+
+            it("should place client in processing state", () => {
+                expect(fsm.currentState(job)).toBe("processing");
+            });
+
+            it("should not fire transitioned events", () => {
+                expect(transitionedEvents).toHaveLength(0);
+            });
+
+            it("should not start the timer (_onEnter does not fire)", () => {
+                // Timer should be null because rehydrate() is silent
+                expect(job.timer).toBeNull();
+            });
+        });
+
+        describe("when resume is dispatched after rehydrating into processing", () => {
+            let job: any;
+
+            beforeEach(() => {
+                jest.spyOn(Math, "random").mockReturnValue(0.9);
+                job = makeJob();
+                fsm.rehydrate(job, "processing");
+                fsm.handle(job, "resume");
+            });
+
+            it("should stay in processing state", () => {
+                expect(fsm.currentState(job)).toBe("processing");
+            });
+
+            it("should start the tick timer", () => {
+                expect(job.timer).not.toBeNull();
+            });
+
+            it("should advance currentStep when ticks fire", () => {
+                jest.advanceTimersByTime(STEP_DURATION_MS);
+                expect(job.currentStep).toBe(1);
+            });
+        });
+
+        describe("when rehydrating with an unknown state name", () => {
+            let job: any;
+            let thrownError: Error | null;
+
+            beforeEach(() => {
+                job = makeJob();
+                thrownError = null;
+
+                try {
+                    fsm.rehydrate(job, "nonexistent-state");
+                } catch (err) {
+                    thrownError = err as Error;
+                }
+            });
+
+            it("should throw an error", () => {
+                expect(thrownError).not.toBeNull();
+            });
+
+            it("should include the unknown state name in the error message", () => {
+                expect(thrownError?.message).toContain("nonexistent-state");
+            });
+        });
+    });
+
+    // =========================================================================
+    // FAILURE_CHANCE boundary — verify it's actually used
+    // =========================================================================
+
+    describe("failure chance", () => {
+        describe("when Math.random returns exactly FAILURE_CHANCE (boundary case)", () => {
+            let job: any;
+
+            beforeEach(() => {
+                // random() returning FAILURE_CHANCE is NOT a failure (condition: < FAILURE_CHANCE)
+                jest.spyOn(Math, "random").mockReturnValue(FAILURE_CHANCE);
+                job = makeJob();
+                fsm.handle(job, "initialize");
+                fsm.handle(job, "start");
+                jest.advanceTimersByTime(STEP_DURATION_MS);
+            });
+
+            it("should not fail when random equals FAILURE_CHANCE exactly", () => {
+                expect(fsm.currentState(job)).toBe("processing");
+            });
+        });
+    });
+});

--- a/examples/job-queue/src/fsm.test.ts
+++ b/examples/job-queue/src/fsm.test.ts
@@ -271,32 +271,6 @@ describe("Job Queue FSM (fsm.ts)", () => {
     });
 
     // =========================================================================
-    // timer cleared on _onExit from processing
-    // =========================================================================
-
-    describe("processing state — timer cleanup on exit", () => {
-        describe("when the job pauses (exiting processing)", () => {
-            let job: any;
-
-            beforeEach(() => {
-                jest.spyOn(Math, "random").mockReturnValue(0.9);
-                job = makeJob();
-                fsm.handle(job, "initialize");
-                fsm.handle(job, "start");
-
-                // Confirm timer is running
-                expect(job.timer).not.toBeNull();
-
-                fsm.handle(job, "pause");
-            });
-
-            it("should clear the timer via _onExit", () => {
-                expect(job.timer).toBeNull();
-            });
-        });
-    });
-
-    // =========================================================================
     // rehydrate() — silent state restoration
     // =========================================================================
 
@@ -416,6 +390,242 @@ describe("Job Queue FSM (fsm.ts)", () => {
 
             it("should not fail when random equals FAILURE_CHANCE exactly", () => {
                 expect(fsm.currentState(job)).toBe("processing");
+            });
+        });
+    });
+
+    // =========================================================================
+    // rehydrate() — all remaining persisted states
+    // =========================================================================
+
+    describe("rehydrate() into paused state", () => {
+        describe("when a client is rehydrated into paused", () => {
+            let job: any;
+            let transitionedEvents: any[];
+
+            beforeEach(() => {
+                job = makeJob();
+                transitionedEvents = [];
+                fsm.on("transitioned", (data: any) => transitionedEvents.push(data));
+                fsm.rehydrate(job, "paused");
+            });
+
+            it("should place client in paused state", () => {
+                expect(fsm.currentState(job)).toBe("paused");
+            });
+
+            it("should not emit transitioned events", () => {
+                expect(transitionedEvents).toHaveLength(0);
+            });
+
+            it("should not start a timer", () => {
+                expect(job.timer).toBeNull();
+            });
+        });
+
+        describe("when resume is dispatched after rehydrating into paused", () => {
+            let job: any;
+
+            beforeEach(() => {
+                jest.spyOn(Math, "random").mockReturnValue(0.9);
+                job = makeJob();
+                fsm.rehydrate(job, "paused");
+                fsm.handle(job, "resume");
+            });
+
+            it("should transition to processing", () => {
+                expect(fsm.currentState(job)).toBe("processing");
+            });
+
+            it("should start the tick timer via _onEnter", () => {
+                expect(job.timer).not.toBeNull();
+            });
+        });
+    });
+
+    describe("rehydrate() into failed state", () => {
+        describe("when a client is rehydrated into failed", () => {
+            let job: any;
+            let handlingEvents: any[];
+
+            beforeEach(() => {
+                job = makeJob({ currentStep: 3 });
+                handlingEvents = [];
+                fsm.on("handling", (data: any) => handlingEvents.push(data));
+                fsm.rehydrate(job, "failed");
+            });
+
+            it("should place client in failed state", () => {
+                expect(fsm.currentState(job)).toBe("failed");
+            });
+
+            it("should not emit handling events", () => {
+                expect(handlingEvents).toHaveLength(0);
+            });
+
+            it("should not modify currentStep", () => {
+                expect(job.currentStep).toBe(3);
+            });
+        });
+
+        describe("when retry is dispatched after rehydrating into failed", () => {
+            let job: any;
+
+            beforeEach(() => {
+                jest.spyOn(Math, "random").mockReturnValue(0.9);
+                job = makeJob({ currentStep: 3 });
+                fsm.rehydrate(job, "failed");
+                fsm.handle(job, "retry");
+            });
+
+            it("should reset currentStep to 0", () => {
+                expect(job.currentStep).toBe(0);
+            });
+
+            it("should transition to processing", () => {
+                expect(fsm.currentState(job)).toBe("processing");
+            });
+        });
+    });
+
+    // =========================================================================
+    // startTicker guard — timer already running when startTicker is called
+    // =========================================================================
+
+    describe("startTicker guard — existing timer cleared before restart", () => {
+        describe("when resume is dispatched while already in processing with an active timer", () => {
+            let job: any;
+            let timerBeforeResume: any;
+
+            beforeEach(() => {
+                jest.spyOn(Math, "random").mockReturnValue(0.9);
+                job = makeJob();
+                fsm.handle(job, "initialize");
+                fsm.handle(job, "start");
+                // Timer is running. Capture the handle to verify it gets replaced.
+                timerBeforeResume = job.timer;
+                fsm.handle(job, "resume");
+            });
+
+            it("should remain in processing", () => {
+                expect(fsm.currentState(job)).toBe("processing");
+            });
+
+            it("should replace the old timer with a new one", () => {
+                expect(job.timer).not.toBeNull();
+                expect(job.timer).not.toBe(timerBeforeResume);
+            });
+        });
+    });
+
+    // =========================================================================
+    // Boundary: job with currentStep already at totalSteps when tick fires
+    // =========================================================================
+
+    describe("tick handler — currentStep already at totalSteps when tick fires", () => {
+        describe("when a job starts with currentStep equal to totalSteps", () => {
+            let job: any;
+
+            beforeEach(() => {
+                jest.spyOn(Math, "random").mockReturnValue(0.9);
+                job = makeJob({ currentStep: TOTAL_STEPS });
+                fsm.handle(job, "initialize");
+                fsm.handle(job, "start");
+                jest.advanceTimersByTime(STEP_DURATION_MS);
+            });
+
+            it("should complete on the first tick", () => {
+                expect(fsm.currentState(job)).toBe("completed");
+            });
+
+            it("should clear the timer on completion", () => {
+                expect(job.timer).toBeNull();
+            });
+        });
+    });
+
+    // =========================================================================
+    // Multiple jobs — independent state tracking via WeakMap
+    // =========================================================================
+
+    describe("multiple jobs — independent state tracking", () => {
+        describe("when two jobs are processed concurrently and one fails", () => {
+            let jobA: any;
+            let jobB: any;
+            let mockRandom: any;
+
+            beforeEach(() => {
+                mockRandom = jest.spyOn(Math, "random");
+                jobA = makeJob({ id: 1, name: "Ghostbusters Job" });
+                jobB = makeJob({ id: 2, name: "Ferris Bueller Job" });
+
+                // Both start in processing
+                fsm.handle(jobA, "initialize");
+                fsm.handle(jobB, "initialize");
+                fsm.handle(jobA, "start");
+                fsm.handle(jobB, "start");
+
+                // On next tick, jobA fails, jobB succeeds
+                // We need to control which job's tick calls get which random value.
+                // The tick handler calls Math.random() once per tick, so we alternate.
+                let callCount = 0;
+                mockRandom.mockImplementation(() => {
+                    callCount++;
+                    // jobA ticks first (it was started first), jobB ticks second
+                    return callCount % 2 === 1 ? 0 : 0.9;
+                });
+
+                jest.advanceTimersByTime(STEP_DURATION_MS);
+            });
+
+            it("should fail jobA", () => {
+                expect(fsm.currentState(jobA)).toBe("failed");
+            });
+
+            it("should keep jobB in processing", () => {
+                expect(fsm.currentState(jobB)).toBe("processing");
+            });
+
+            it("should clear jobA timer and keep jobB timer active", () => {
+                expect(jobA.timer).toBeNull();
+                expect(jobB.timer).not.toBeNull();
+            });
+        });
+    });
+
+    // =========================================================================
+    // Multiple rapid pause/resume cycles
+    // =========================================================================
+
+    describe("multiple rapid pause/resume cycles", () => {
+        describe("when a job is paused and resumed three times in succession", () => {
+            let job: any;
+
+            beforeEach(() => {
+                jest.spyOn(Math, "random").mockReturnValue(0.9);
+                job = makeJob();
+                fsm.handle(job, "initialize");
+                fsm.handle(job, "start");
+
+                fsm.handle(job, "pause");
+                fsm.handle(job, "resume");
+                fsm.handle(job, "pause");
+                fsm.handle(job, "resume");
+                fsm.handle(job, "pause");
+                fsm.handle(job, "resume");
+            });
+
+            it("should end up in processing after the final resume", () => {
+                expect(fsm.currentState(job)).toBe("processing");
+            });
+
+            it("should have an active timer after the final resume", () => {
+                expect(job.timer).not.toBeNull();
+            });
+
+            it("should still advance currentStep when ticks fire", () => {
+                jest.advanceTimersByTime(STEP_DURATION_MS);
+                expect(job.currentStep).toBe(1);
             });
         });
     });

--- a/examples/job-queue/src/fsm.ts
+++ b/examples/job-queue/src/fsm.ts
@@ -1,0 +1,222 @@
+// =============================================================================
+// fsm.ts — Job Queue BehavioralFsm
+//
+// This file is the centerpiece of the example. Read it alongside main.ts.
+//
+// One BehavioralFsm drives all job clients. Each job is a plain JobClient
+// object — the FSM stores state separately in a WeakMap. This is the
+// multi-client pattern: one FSM definition, many independent clients.
+//
+// Five states: queued → processing → completed
+//                              ↕
+//                           paused
+//                              ↓
+//                           failed → (retry) → processing
+//
+// THE KEY TEACHING MOMENT IS THE `resume` INPUT ON `processing`:
+//
+// After a page reload, main.ts calls fsm.rehydrate(job, savedState) to silently
+// restore the client's position in the state machine. rehydrate() is silent —
+// _onEnter does NOT fire. So any job that was processing when the page refreshed
+// has no timer running. main.ts fixes this by calling fsm.handle(job, "resume"),
+// which hits the `resume` handler in `processing` and restarts the tick timer
+// WITHOUT transitioning away from `processing`.
+//
+// This two-step restore (rehydrate + resume) is the pattern the example teaches.
+//
+// INSTANCE CAPTURE FOR TIMER CALLBACKS:
+// `let fsm` is declared before createJobQueueFsm() so the tick timer can close
+// over it. JavaScript is single-threaded — setTimeout callbacks are async —
+// so `fsm` is always assigned before any timer fires.
+// =============================================================================
+
+import { createBehavioralFsm } from "machina";
+import { STEP_DURATION_MS, FAILURE_CHANCE, TOTAL_STEPS, type JobClient } from "./config";
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+/** Start the repeating tick timer for a job. Stored on ctx.timer so _onExit
+ *  and the pause/fail/complete paths can clear it without a stale tick firing. */
+const startTicker = (ctx: JobClient, getFsm: () => ReturnType<typeof createJobQueueFsm>) => {
+    // Clear any leftover timer before starting a new one — belt and suspenders,
+    // since _onExit should handle this, but double-clearing is a no-op.
+    if (ctx.timer !== null) {
+        clearTimeout(ctx.timer);
+    }
+
+    const tick = () => {
+        // Clear the timer reference before handling so _onExit can detect that
+        // the tick itself is in progress. After handle() returns, we check
+        // whether the job is still processing before rescheduling.
+        ctx.timer = null;
+        getFsm().handle(ctx, "tick");
+        // Only reschedule if the job is still in processing. If the tick handler
+        // transitioned to failed/completed, _onExit has already cleared the timer
+        // (setting ctx.timer to null) and we should not restart it.
+        if (ctx.timer === null && getFsm().currentState(ctx) === "processing") {
+            ctx.timer = setTimeout(tick, STEP_DURATION_MS);
+        }
+    };
+
+    ctx.timer = setTimeout(tick, STEP_DURATION_MS);
+};
+
+/** Clear the tick timer. Safe to call when timer is already null. */
+const clearTicker = (ctx: JobClient) => {
+    if (ctx.timer !== null) {
+        clearTimeout(ctx.timer);
+        ctx.timer = null;
+    }
+};
+
+// -----------------------------------------------------------------------------
+// Factory
+// -----------------------------------------------------------------------------
+
+/**
+ * Create a new BehavioralFsm instance for the job queue.
+ * Exported for test isolation — each test creates its own instance.
+ */
+export function createJobQueueFsm() {
+    // Declared before createBehavioralFsm() so timer callbacks can close over it.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let instance: any;
+
+    // eslint-disable-next-line prefer-const
+    instance = createBehavioralFsm<JobClient, Record<string, Record<string, unknown>>>({
+        id: "job-queue",
+        initialState: "queued",
+
+        states: {
+            // ------------------------------------------------------------------
+            // queued — job is registered but not yet running
+            //
+            // `initialize` is a no-op that exists purely to trigger lazy init.
+            // BehavioralFsm registers a client on first handle(), which fires
+            // _onEnter for initialState. We need jobs visible in "queued" state
+            // before the user clicks "Start", so main.ts calls handle(job, "initialize")
+            // immediately after creating a job. The handler does nothing — the
+            // side effect we want is the WeakMap registration.
+            // ------------------------------------------------------------------
+            queued: {
+                initialize() {
+                    // intentional no-op — see module comment above
+                },
+
+                start() {
+                    return "processing";
+                },
+            },
+
+            // ------------------------------------------------------------------
+            // processing — the tick timer runs, advancing currentStep
+            //
+            // _onEnter starts the tick timer. On each tick, the job has a
+            // FAILURE_CHANCE of failing, and completes when currentStep reaches
+            // totalSteps. _onExit clears the timer — this is the safety net
+            // for all exit paths (pause, fail, complete, external transition).
+            //
+            // `resume` in this state is the post-rehydrate path: rehydrate()
+            // places the client back in "processing" but doesn't fire _onEnter,
+            // so the tick timer isn't running. main.ts dispatches "resume" to
+            // restart it. This handler restarts the timer without transitioning.
+            //
+            // `pause` exits to paused. When the user resumes from paused, the
+            // FSM transitions back to processing and _onEnter fires normally.
+            // ------------------------------------------------------------------
+            processing: {
+                _onEnter({ ctx }: { ctx: JobClient }) {
+                    startTicker(ctx, () => instance);
+                },
+
+                _onExit({ ctx }: { ctx: JobClient }) {
+                    // Clear the timer on every exit — prevents stale ticks from
+                    // firing after the job has left this state.
+                    clearTicker(ctx);
+                },
+
+                tick({ ctx }: { ctx: JobClient }) {
+                    // Random failure check — keeps the demo interesting
+                    if (Math.random() < FAILURE_CHANCE) {
+                        return "failed";
+                    }
+
+                    ctx.currentStep++;
+
+                    if (ctx.currentStep >= TOTAL_STEPS) {
+                        return "completed";
+                    }
+
+                    // No return = stay in processing
+                },
+
+                pause() {
+                    return "paused";
+                },
+
+                // Post-rehydrate timer restart. Does NOT transition — the job
+                // stays in processing. This is what makes rehydrate() useful:
+                // the FSM restores position, the app re-establishes side effects.
+                resume({ ctx }: { ctx: JobClient }) {
+                    startTicker(ctx, () => instance);
+                },
+            },
+
+            // ------------------------------------------------------------------
+            // paused — timer is stopped, job is idle
+            //
+            // resume transitions back to processing, which fires _onEnter and
+            // starts a fresh tick timer. No manual timer restart needed here
+            // because _onEnter handles it.
+            // ------------------------------------------------------------------
+            paused: {
+                resume() {
+                    return "processing";
+                },
+            },
+
+            // ------------------------------------------------------------------
+            // failed — something went wrong during a tick
+            //
+            // _onEnter clears the timer as a safety net (the processing _onExit
+            // should have already done it, but defense in depth is cheap).
+            //
+            // retry resets currentStep to 0 and transitions to processing,
+            // starting fresh. The job doesn't carry over partial progress —
+            // real retry semantics are domain-specific; resetting is a
+            // reasonable default for a demo.
+            // ------------------------------------------------------------------
+            failed: {
+                _onEnter({ ctx }: { ctx: JobClient }) {
+                    clearTicker(ctx);
+                },
+
+                retry({ ctx }: { ctx: JobClient }) {
+                    ctx.currentStep = 0;
+                    return "processing";
+                },
+            },
+
+            // ------------------------------------------------------------------
+            // completed — terminal state, job is done
+            //
+            // _onEnter clears the timer as a safety net. No inputs are handled
+            // from this state — the job is done and stays done.
+            // ------------------------------------------------------------------
+            completed: {
+                _onEnter({ ctx }: { ctx: JobClient }) {
+                    clearTicker(ctx);
+                },
+            },
+        },
+    });
+
+    return instance;
+}
+
+// Module-level singleton — main.ts imports createJobQueueFsm() directly
+// and manages its own instance. This export is kept for convenience but
+// main.ts creates fresh instances as needed (e.g., after Clear Storage).
+export const fsm = createJobQueueFsm();

--- a/examples/job-queue/src/main.ts
+++ b/examples/job-queue/src/main.ts
@@ -1,0 +1,325 @@
+// =============================================================================
+// main.ts — Job Queue wiring
+//
+// This file orchestrates everything: FSM events → UI, DOM events → FSM inputs,
+// and the persist/restore cycle that is the purpose of this example.
+//
+// READ THIS SECTION FIRST — it's the teaching moment:
+//
+// ON PAGE LOAD:
+//   1. Read localStorage.
+//   2. For each persisted job, recreate the client object and call:
+//        fsm.rehydrate(job, savedState)
+//      This silently places the client at its previous state. No _onEnter fires.
+//      No events emit. The WeakMap entry is created as if the client had always
+//      been in that state.
+//   3. For any job that was `processing`, call:
+//        fsm.handle(job, "resume")
+//      This triggers the `resume` handler in the `processing` state, which
+//      restarts the tick timer WITHOUT transitioning. The job picks up where
+//      it left off.
+//
+// That two-step pattern — rehydrate() then handle("resume") — is the whole
+// point. rehydrate() is silent by design; the app owns re-establishing
+// side effects. This is the canonical machina rehydration pattern.
+//
+// WIRING ONLY: no business logic here. DOM manipulation goes in ui.ts.
+// FSM state machine logic stays in fsm.ts. This file just connects them.
+// =============================================================================
+
+import {
+    MAX_JOBS,
+    STORAGE_KEY,
+    STATE_PROCESSING,
+    TOTAL_STEPS,
+    type JobClient,
+    type JobState,
+    type PersistedJob,
+    type StorageShape,
+} from "./config";
+import { createJobQueueFsm } from "./fsm";
+import {
+    renderJobList,
+    renderEmptyState,
+    renderRestoredBanner,
+    updateJobCard,
+    initAddJobButton,
+    initClearStorageButton,
+    setAddJobEnabled,
+} from "./ui";
+
+// -----------------------------------------------------------------------------
+// App state — kept at module level for event handler closures
+// -----------------------------------------------------------------------------
+
+let fsm = createJobQueueFsm();
+let jobs: JobClient[] = [];
+let nextId = 1;
+
+// Track current state per job ID so ui.ts doesn't need FSM access.
+// We maintain this map ourselves on every transitioned event.
+const jobStates = new Map<number, JobState>();
+
+// -----------------------------------------------------------------------------
+// Serialization helpers
+// -----------------------------------------------------------------------------
+
+/**
+ * Serialize all active jobs and their current FSM states to localStorage.
+ * Called on every `transitioned` event to keep storage fresh.
+ *
+ * `timer` is excluded — setTimeout handles are not serializable.
+ * The timer is re-established via fsm.handle(job, "resume") on restore.
+ */
+const persistJobs = (): void => {
+    const shape: StorageShape = {
+        nextId,
+        jobs: jobs.map(job => {
+            const state = fsm.currentState(job) as JobState;
+            const persisted: PersistedJob = {
+                state,
+                id: job.id,
+                name: job.name,
+                currentStep: job.currentStep,
+                totalSteps: job.totalSteps,
+                createdAt: job.createdAt,
+            };
+            return persisted;
+        }),
+    };
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(shape));
+};
+
+// -----------------------------------------------------------------------------
+// Restore path — the core teaching moment
+// -----------------------------------------------------------------------------
+
+/**
+ * Attempt to restore jobs from localStorage on page load.
+ * Returns the number of jobs restored, or -1 if storage was stale/corrupt.
+ *
+ * Uses try/catch because rehydrate() throws for unknown state names — this
+ * handles the case where a schema change makes old data incompatible.
+ */
+const restoreFromStorage = (): number => {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+        return 0;
+    }
+
+    let shape: StorageShape;
+    try {
+        shape = JSON.parse(raw) as StorageShape;
+    } catch {
+        // JSON.parse failed — storage is corrupt
+        return -1;
+    }
+
+    if (!shape.jobs || !Array.isArray(shape.jobs)) {
+        return -1;
+    }
+
+    try {
+        for (const persisted of shape.jobs) {
+            // Reconstruct the client object. timer is excluded from serialization;
+            // we set it to null here and re-establish it via "resume" below.
+            const job: JobClient = {
+                id: persisted.id,
+                name: persisted.name,
+                currentStep: persisted.currentStep,
+                totalSteps: persisted.totalSteps,
+                timer: null,
+                createdAt: persisted.createdAt,
+                // Mark as restored so the UI can show the "restored" badge.
+                // The FSM has no concept of this — it's purely a UI hint.
+                restoredFromStorage: true,
+            };
+
+            // STEP 1: Silently place the client at its saved state.
+            // rehydrate() does NOT fire _onEnter, so the tick timer does not start.
+            fsm.rehydrate(job, persisted.state);
+
+            jobStates.set(job.id, persisted.state);
+            jobs.push(job);
+
+            // STEP 2: If the job was processing, restart its timer.
+            // rehydrate() placed it in "processing" but _onEnter didn't fire.
+            // The "resume" handler in processing restarts the tick without transitioning.
+            if (persisted.state === STATE_PROCESSING) {
+                fsm.handle(job, "resume");
+            }
+        }
+
+        nextId = shape.nextId;
+        return jobs.length;
+    } catch {
+        // rehydrate() threw — saved state names are no longer valid
+        // (likely a schema change). Start fresh.
+        jobs = [];
+        jobStates.clear();
+        return -1;
+    }
+};
+
+// -----------------------------------------------------------------------------
+// Action handler — dispatches FSM inputs from UI button clicks
+// -----------------------------------------------------------------------------
+
+const handleJobAction = (job: JobClient, input: string): void => {
+    fsm.handle(job, input);
+};
+
+// -----------------------------------------------------------------------------
+// Initialize
+// -----------------------------------------------------------------------------
+
+/**
+ * Wire up all FSM event subscriptions and DOM event listeners.
+ * Called once at page load. Returns a cleanup function for beforeunload.
+ */
+const init = (): (() => void) => {
+    // -------------------------------------------------------------------------
+    // Restore from localStorage (before any rendering)
+    // -------------------------------------------------------------------------
+
+    const restoredCount = restoreFromStorage();
+
+    if (restoredCount === -1) {
+        // Storage was stale or corrupt — wipe it and start fresh
+        localStorage.removeItem(STORAGE_KEY);
+        console.warn("Job queue: stored data was stale or incompatible — starting fresh.");
+    } else if (restoredCount > 0) {
+        renderRestoredBanner(restoredCount);
+    }
+
+    // -------------------------------------------------------------------------
+    // FSM event subscriptions
+    // -------------------------------------------------------------------------
+
+    // `transitioned` fires after every state change. This is where we:
+    //   1. Update jobStates map so the UI stays in sync.
+    //   2. Update the affected job's card.
+    //   3. Persist all jobs to localStorage.
+    const transitionedSub = fsm.on("transitioned", (data: unknown) => {
+        const { client, toState } = data as { client: JobClient; toState: JobState };
+        jobStates.set(client.id, toState);
+        updateJobCard(client, toState, handleJobAction);
+        persistJobs();
+    });
+
+    // `handling` subscription for debugging — logs which input is being processed.
+    // Matches the pattern in shopping-cart and connectivity examples.
+    const handlingSub = fsm.on("handling", (data: unknown) => {
+        const { inputName, client } = data as { inputName: string; client: JobClient | undefined };
+        console.debug(`[job-queue] handling "${inputName}" for job #${client?.id}`);
+    });
+
+    // -------------------------------------------------------------------------
+    // DOM event wiring
+    // -------------------------------------------------------------------------
+
+    const removeAddJob = initAddJobButton(() => {
+        if (jobs.length >= MAX_JOBS) {
+            return;
+        }
+
+        const job: JobClient = {
+            id: nextId++,
+            name: `Job #${nextId - 1}`,
+            currentStep: 0,
+            totalSteps: TOTAL_STEPS,
+            timer: null,
+            createdAt: new Date().toISOString(),
+            restoredFromStorage: false,
+        };
+
+        // Register the client in the FSM WeakMap by calling the no-op "initialize"
+        // input. This fires _onEnter for "queued" and makes currentState(job)
+        // return "queued" before the user clicks Start.
+        fsm.handle(job, "initialize");
+
+        jobs.push(job);
+        jobStates.set(job.id, "queued");
+        persistJobs();
+
+        // Re-render the full list — simpler than trying to insert one card
+        // at the right position.
+        renderJobList(jobs, jobStates, handleJobAction);
+        setAddJobEnabled(jobs.length < MAX_JOBS);
+    });
+
+    const removeClearStorage = initClearStorageButton(() => {
+        // Dispose the current FSM — clears all subscriptions and timers
+        fsm.dispose();
+
+        // Create a fresh FSM and re-subscribe
+        fsm = createJobQueueFsm();
+        jobs = [];
+        jobStates.clear();
+        nextId = 1;
+
+        localStorage.removeItem(STORAGE_KEY);
+
+        renderEmptyState();
+        setAddJobEnabled(true);
+
+        // Re-wire FSM subscriptions on the new instance
+        fsm.on("transitioned", (data: unknown) => {
+            const { client, toState } = data as { client: JobClient; toState: JobState };
+            jobStates.set(client.id, toState);
+            updateJobCard(client, toState, handleJobAction);
+            persistJobs();
+        });
+
+        fsm.on("handling", (data: unknown) => {
+            const { inputName, client } = data as {
+                inputName: string;
+                client: JobClient | undefined;
+            };
+            console.debug(`[job-queue] handling "${inputName}" for job #${client?.id}`);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Initial render
+    // -------------------------------------------------------------------------
+
+    if (jobs.length === 0) {
+        renderEmptyState();
+    } else {
+        renderJobList(jobs, jobStates, handleJobAction);
+    }
+
+    setAddJobEnabled(jobs.length < MAX_JOBS);
+
+    // -------------------------------------------------------------------------
+    // Cleanup function — called on beforeunload
+    // -------------------------------------------------------------------------
+
+    return () => {
+        transitionedSub.off();
+        handlingSub.off();
+        removeAddJob();
+        removeClearStorage();
+
+        // Clear all timers before unload — prevents timer callbacks from
+        // firing during the unload sequence and corrupting storage writes.
+        for (const job of jobs) {
+            if (job.timer !== null) {
+                clearTimeout(job.timer);
+                job.timer = null;
+            }
+        }
+
+        fsm.dispose();
+    };
+};
+
+// -----------------------------------------------------------------------------
+// Bootstrap
+// -----------------------------------------------------------------------------
+
+const cleanup = init();
+
+window.addEventListener("beforeunload", cleanup);

--- a/examples/job-queue/src/main.ts
+++ b/examples/job-queue/src/main.ts
@@ -28,9 +28,11 @@
 // =============================================================================
 
 import {
+    INPUT_TICK,
     MAX_JOBS,
     STORAGE_KEY,
     STATE_PROCESSING,
+    STATE_QUEUED,
     TOTAL_STEPS,
     type JobClient,
     type JobState,
@@ -197,23 +199,50 @@ const init = (): (() => void) => {
     // FSM event subscriptions
     // -------------------------------------------------------------------------
 
-    // `transitioned` fires after every state change. This is where we:
-    //   1. Update jobStates map so the UI stays in sync.
-    //   2. Update the affected job's card.
-    //   3. Persist all jobs to localStorage.
-    const transitionedSub = fsm.on("transitioned", (data: unknown) => {
-        const { client, toState } = data as { client: JobClient; toState: JobState };
-        jobStates.set(client.id, toState);
-        updateJobCard(client, toState, handleJobAction);
-        persistJobs();
-    });
+    // Extracted so clear-storage can re-wire after creating a new FSM instance
+    // and the cleanup function always references the live subscription handles.
+    let transitionedSub: { off: () => void };
+    let handledSub: { off: () => void };
+    let handlingSub: { off: () => void };
 
-    // `handling` subscription for debugging — logs which input is being processed.
-    // Matches the pattern in shopping-cart and connectivity examples.
-    const handlingSub = fsm.on("handling", (data: unknown) => {
-        const { inputName, client } = data as { inputName: string; client: JobClient | undefined };
-        console.debug(`[job-queue] handling "${inputName}" for job #${client?.id}`);
-    });
+    const wireFsmSubscriptions = (): void => {
+        // `transitioned` fires after every state change. This is where we:
+        //   1. Update jobStates map so the UI stays in sync.
+        //   2. Update the affected job's card.
+        //   3. Persist all jobs to localStorage.
+        transitionedSub = fsm.on("transitioned", (data: unknown) => {
+            const { client, toState } = data as { client: JobClient; toState: JobState };
+            jobStates.set(client.id, toState);
+            updateJobCard(client, toState, handleJobAction);
+            persistJobs();
+        });
+
+        // `handled` fires after every input — including ticks that stay in
+        // processing. Without this, the progress bar only updates when the
+        // job transitions to a different state (completed/failed/paused).
+        handledSub = fsm.on("handled", (data: unknown) => {
+            const { client, inputName } = data as { client: JobClient; inputName: string };
+            if (inputName === INPUT_TICK) {
+                const state = jobStates.get(client.id);
+                if (state) {
+                    updateJobCard(client, state, handleJobAction);
+                    persistJobs();
+                }
+            }
+        });
+
+        // `handling` subscription for debugging — logs which input is being processed.
+        // Matches the pattern in shopping-cart and connectivity examples.
+        handlingSub = fsm.on("handling", (data: unknown) => {
+            const { inputName, client } = data as {
+                inputName: string;
+                client: JobClient | undefined;
+            };
+            console.debug(`[job-queue] handling "${inputName}" for job #${client?.id}`);
+        });
+    };
+
+    wireFsmSubscriptions();
 
     // -------------------------------------------------------------------------
     // DOM event wiring
@@ -240,7 +269,7 @@ const init = (): (() => void) => {
         fsm.handle(job, "initialize");
 
         jobs.push(job);
-        jobStates.set(job.id, "queued");
+        jobStates.set(job.id, STATE_QUEUED);
         persistJobs();
 
         // Re-render the full list — simpler than trying to insert one card
@@ -264,21 +293,7 @@ const init = (): (() => void) => {
         renderEmptyState();
         setAddJobEnabled(true);
 
-        // Re-wire FSM subscriptions on the new instance
-        fsm.on("transitioned", (data: unknown) => {
-            const { client, toState } = data as { client: JobClient; toState: JobState };
-            jobStates.set(client.id, toState);
-            updateJobCard(client, toState, handleJobAction);
-            persistJobs();
-        });
-
-        fsm.on("handling", (data: unknown) => {
-            const { inputName, client } = data as {
-                inputName: string;
-                client: JobClient | undefined;
-            };
-            console.debug(`[job-queue] handling "${inputName}" for job #${client?.id}`);
-        });
+        wireFsmSubscriptions();
     });
 
     // -------------------------------------------------------------------------
@@ -299,6 +314,7 @@ const init = (): (() => void) => {
 
     return () => {
         transitionedSub.off();
+        handledSub.off();
         handlingSub.off();
         removeAddJob();
         removeClearStorage();

--- a/examples/job-queue/src/style.css
+++ b/examples/job-queue/src/style.css
@@ -1,0 +1,408 @@
+/* =============================================================================
+   style.css — Job Queue demo
+   Conference-talk quality: clear at 1280px, readable on a projector.
+   ============================================================================= */
+
+/* -----------------------------------------------------------------------------
+   Custom properties — state colors + base palette
+   ----------------------------------------------------------------------------- */
+
+:root {
+    --color-queued: #6b7280;
+    --color-processing: #2563eb;
+    --color-paused: #d97706;
+    --color-failed: #dc2626;
+    --color-completed: #16a34a;
+
+    --color-bg: #f9fafb;
+    --color-surface: #ffffff;
+    --color-border: #e5e7eb;
+    --color-text: #111827;
+    --color-text-muted: #6b7280;
+
+    --radius: 8px;
+    --shadow: 0 1px 3px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.06);
+
+    font-family:
+        system-ui,
+        -apple-system,
+        sans-serif;
+}
+
+/* -----------------------------------------------------------------------------
+   Reset
+   ----------------------------------------------------------------------------- */
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background: var(--color-bg);
+    color: var(--color-text);
+    line-height: 1.5;
+    min-height: 100vh;
+}
+
+/* -----------------------------------------------------------------------------
+   Page layout
+   ----------------------------------------------------------------------------- */
+
+.page-wrapper {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 2rem 1.5rem;
+}
+
+/* -----------------------------------------------------------------------------
+   Header
+   ----------------------------------------------------------------------------- */
+
+.page-header {
+    margin-bottom: 2rem;
+}
+
+.page-title {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: var(--color-text);
+}
+
+.page-subtitle {
+    font-size: 0.95rem;
+    color: var(--color-text-muted);
+    margin-top: 0.25rem;
+    margin-bottom: 1rem;
+}
+
+.page-intro {
+    font-size: 0.9rem;
+    color: var(--color-text-muted);
+    max-width: 65ch;
+    line-height: 1.6;
+}
+
+/* -----------------------------------------------------------------------------
+   Controls bar — Add Job + Clear Storage buttons
+   ----------------------------------------------------------------------------- */
+
+.controls-bar {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+    margin-bottom: 1.5rem;
+}
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.5rem 1rem;
+    border-radius: var(--radius);
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    border: none;
+    transition:
+        opacity 0.15s,
+        background 0.15s;
+}
+
+.btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.btn--primary {
+    background: #1d4ed8;
+    color: #fff;
+}
+
+.btn--primary:hover:not(:disabled) {
+    background: #1e40af;
+}
+
+.btn--secondary {
+    background: var(--color-surface);
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
+}
+
+.btn--secondary:hover:not(:disabled) {
+    background: #f3f4f6;
+}
+
+/* -----------------------------------------------------------------------------
+   Restored banner
+   ----------------------------------------------------------------------------- */
+
+.restored-banner {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    background: #eff6ff;
+    border: 1px solid #bfdbfe;
+    border-radius: var(--radius);
+    margin-bottom: 1.5rem;
+    font-size: 0.875rem;
+    color: #1e40af;
+    cursor: pointer;
+}
+
+.restored-banner[hidden] {
+    display: none;
+}
+
+.restored-banner__icon {
+    font-size: 1rem;
+    flex-shrink: 0;
+}
+
+/* -----------------------------------------------------------------------------
+   Job list
+   ----------------------------------------------------------------------------- */
+
+#job-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+/* -----------------------------------------------------------------------------
+   Job cards
+   ----------------------------------------------------------------------------- */
+
+.job-card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    padding: 1rem 1.25rem;
+    box-shadow: var(--shadow);
+    border-left: 4px solid var(--color-queued);
+    transition: border-color 0.25s;
+}
+
+.job-card--queued {
+    border-left-color: var(--color-queued);
+}
+.job-card--processing {
+    border-left-color: var(--color-processing);
+}
+.job-card--paused {
+    border-left-color: var(--color-paused);
+}
+.job-card--failed {
+    border-left-color: var(--color-failed);
+}
+.job-card--completed {
+    border-left-color: var(--color-completed);
+}
+
+.job-card__header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.job-card__name {
+    font-weight: 600;
+    font-size: 0.95rem;
+}
+
+.job-card__restored-badge {
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    background: #eff6ff;
+    color: #1d4ed8;
+    border: 1px solid #bfdbfe;
+    border-radius: 999px;
+    padding: 0.1rem 0.5rem;
+    /* Fade out after a few seconds — the badge is a hint, not a permanent label */
+    animation: badge-fade 8s forwards;
+}
+
+@keyframes badge-fade {
+    0% {
+        opacity: 1;
+    }
+    70% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0.2;
+    }
+}
+
+.job-card__state-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.job-card__state-desc {
+    font-size: 0.8rem;
+    color: var(--color-text-muted);
+}
+
+/* -----------------------------------------------------------------------------
+   State badges
+   ----------------------------------------------------------------------------- */
+
+.badge {
+    display: inline-block;
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 0.15rem 0.6rem;
+    border-radius: 999px;
+    letter-spacing: 0.03em;
+    transition:
+        background 0.25s,
+        color 0.25s;
+}
+
+.badge--queued {
+    background: #f3f4f6;
+    color: var(--color-queued);
+}
+.badge--processing {
+    background: #dbeafe;
+    color: var(--color-processing);
+}
+.badge--paused {
+    background: #fef3c7;
+    color: var(--color-paused);
+}
+.badge--failed {
+    background: #fee2e2;
+    color: var(--color-failed);
+}
+.badge--completed {
+    background: #dcfce7;
+    color: var(--color-completed);
+}
+
+/* -----------------------------------------------------------------------------
+   Progress bar
+   ----------------------------------------------------------------------------- */
+
+.job-card__progress-wrap {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.5rem;
+}
+
+.job-card__progress-bar {
+    flex: 1;
+    height: 6px;
+    background: #dbeafe;
+    border-radius: 999px;
+    overflow: hidden;
+    position: relative;
+}
+
+.job-card__progress-bar::after {
+    content: "";
+    display: block;
+    height: 100%;
+    width: inherit;
+    background: var(--color-processing);
+    border-radius: 999px;
+    transition: width 0.4s ease;
+}
+
+/* Width is driven by inline style on the element itself — the ::after pseudo
+   inherits it via width: inherit. */
+.job-card__progress-bar {
+    width: 100%; /* container fills available space */
+}
+
+.job-card__progress-bar[style] {
+    width: 100%; /* reset: the bar background is always 100% wide */
+}
+
+/* The actual fill. We drive progress via a data attribute instead of inline
+   style on the ::after, because ::after can't have its own inline styles.
+   We use a CSS custom property set on the parent instead. */
+
+/* Revisited: use a real child element for the fill (simpler, no pseudo tricks) */
+.job-card__progress-fill {
+    height: 6px;
+    background: var(--color-processing);
+    border-radius: 999px;
+    transition: width 0.4s ease;
+    min-width: 0;
+}
+
+.job-card__progress-label {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    white-space: nowrap;
+    min-width: 3rem;
+    text-align: right;
+}
+
+/* -----------------------------------------------------------------------------
+   Action buttons (inside job cards)
+   ----------------------------------------------------------------------------- */
+
+.job-action-btn {
+    margin-top: 0.25rem;
+    padding: 0.35rem 0.875rem;
+    border-radius: var(--radius);
+    font-size: 0.8rem;
+    font-weight: 500;
+    cursor: pointer;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    color: var(--color-text);
+    transition: background 0.15s;
+}
+
+.job-action-btn:hover {
+    background: #f3f4f6;
+}
+
+/* -----------------------------------------------------------------------------
+   Empty state
+   ----------------------------------------------------------------------------- */
+
+.empty-state {
+    padding: 3rem 1rem;
+    text-align: center;
+}
+
+.empty-state__message {
+    font-size: 1rem;
+    color: var(--color-text-muted);
+    margin-bottom: 0.5rem;
+}
+
+.empty-state__hint {
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+    opacity: 0.7;
+}
+
+/* -----------------------------------------------------------------------------
+   Responsive tweaks
+   ----------------------------------------------------------------------------- */
+
+@media (max-width: 600px) {
+    .page-wrapper {
+        padding: 1rem;
+    }
+
+    .controls-bar {
+        flex-wrap: wrap;
+    }
+}

--- a/examples/job-queue/src/ui.ts
+++ b/examples/job-queue/src/ui.ts
@@ -1,0 +1,300 @@
+// =============================================================================
+// ui.ts — Job Queue DOM rendering
+//
+// Pure DOM manipulation: accepts data, updates the page, returns cleanup fns.
+// No FSM knowledge here — this module doesn't import from fsm.ts or config.ts
+// (except for types and display labels). All state-specific behavior is driven
+// by the state string passed from main.ts.
+//
+// textContent only — no innerHTML interpolation. All element creation goes
+// through createElement + textContent/setAttribute to prevent XSS.
+// =============================================================================
+
+import {
+    MAX_JOBS,
+    STATE_LABELS,
+    STATE_DESCRIPTIONS,
+    STATE_QUEUED,
+    STATE_PROCESSING,
+    STATE_PAUSED,
+    STATE_FAILED,
+    type JobClient,
+    type JobState,
+} from "./config";
+
+// -----------------------------------------------------------------------------
+// Cached element references — grabbed once at module load
+// -----------------------------------------------------------------------------
+
+const getEl = <T extends HTMLElement>(id: string): T => {
+    const el = document.getElementById(id);
+    if (!el) {
+        throw new Error(`ui.ts: missing element #${id} — check index.html`);
+    }
+    return el as T;
+};
+
+// These are referenced in multiple functions, so cache them.
+const jobListEl = () => getEl<HTMLDivElement>("job-list");
+const addJobBtnEl = () => getEl<HTMLButtonElement>("btn-add-job");
+
+// -----------------------------------------------------------------------------
+// Job card creation
+// -----------------------------------------------------------------------------
+
+/** Returns the CSS class for a state badge. Each state gets a distinct color. */
+const stateBadgeClass = (state: JobState): string => `badge badge--${state}`;
+
+/**
+ * Build a contextual action button for a job card based on its current state.
+ * Returns null for terminal states where no action is available.
+ */
+const makeActionButton = (
+    job: JobClient,
+    state: JobState,
+    onAction: (job: JobClient, input: string) => void
+): HTMLButtonElement | null => {
+    let label: string;
+    let input: string;
+
+    if (state === STATE_QUEUED) {
+        label = "Start";
+        input = "start";
+    } else if (state === STATE_PROCESSING) {
+        label = "Pause";
+        input = "pause";
+    } else if (state === STATE_PAUSED) {
+        label = "Resume";
+        input = "resume";
+    } else if (state === STATE_FAILED) {
+        label = "Retry";
+        input = "retry";
+    } else {
+        // completed — no action available
+        return null;
+    }
+
+    const btn = document.createElement("button");
+    btn.className = "job-action-btn";
+    btn.type = "button";
+    btn.textContent = label;
+    btn.addEventListener("click", () => onAction(job, input));
+    return btn;
+};
+
+/**
+ * Create a job card DOM element from scratch.
+ * Used by renderJobList — updateJobCard handles in-place updates.
+ */
+const createJobCard = (
+    job: JobClient,
+    state: JobState,
+    onAction: (job: JobClient, input: string) => void
+): HTMLDivElement => {
+    const card = document.createElement("div");
+    card.className = `job-card job-card--${state}`;
+    card.dataset.jobId = String(job.id);
+
+    // Header row: job name + restored badge
+    const header = document.createElement("div");
+    header.className = "job-card__header";
+
+    const name = document.createElement("span");
+    name.className = "job-card__name";
+    name.textContent = job.name;
+    header.appendChild(name);
+
+    if (job.restoredFromStorage) {
+        const badge = document.createElement("span");
+        badge.className = "job-card__restored-badge";
+        badge.textContent = "restored";
+        header.appendChild(badge);
+    }
+
+    card.appendChild(header);
+
+    // State badge + description
+    const stateRow = document.createElement("div");
+    stateRow.className = "job-card__state-row";
+
+    const stateBadge = document.createElement("span");
+    stateBadge.className = stateBadgeClass(state);
+    stateBadge.textContent = STATE_LABELS[state];
+    stateRow.appendChild(stateBadge);
+
+    const stateDesc = document.createElement("span");
+    stateDesc.className = "job-card__state-desc";
+    stateDesc.textContent = STATE_DESCRIPTIONS[state];
+    stateRow.appendChild(stateDesc);
+
+    card.appendChild(stateRow);
+
+    // Progress bar — only shown while processing
+    if (state === STATE_PROCESSING) {
+        const progressWrap = document.createElement("div");
+        progressWrap.className = "job-card__progress-wrap";
+
+        // Track: the background container
+        const progressTrack = document.createElement("div");
+        progressTrack.className = "job-card__progress-bar";
+
+        // Fill: the colored portion, width driven by inline style
+        const progressFill = document.createElement("div");
+        progressFill.className = "job-card__progress-fill";
+        const pct = Math.round((job.currentStep / job.totalSteps) * 100);
+        progressFill.style.width = `${pct}%`;
+
+        progressTrack.appendChild(progressFill);
+
+        const progressLabel = document.createElement("span");
+        progressLabel.className = "job-card__progress-label";
+        progressLabel.textContent = `${job.currentStep} / ${job.totalSteps}`;
+
+        progressWrap.appendChild(progressTrack);
+        progressWrap.appendChild(progressLabel);
+        card.appendChild(progressWrap);
+    }
+
+    // Action button
+    const actionBtn = makeActionButton(job, state, onAction);
+    if (actionBtn) {
+        card.appendChild(actionBtn);
+    }
+
+    return card;
+};
+
+// -----------------------------------------------------------------------------
+// Public API
+// -----------------------------------------------------------------------------
+
+/**
+ * Render all job cards into the job list container.
+ * Replaces the entire list contents — used on initial load and after reset.
+ *
+ * @param jobs - All active job clients
+ * @param states - Map of job ID → current state
+ * @param onAction - Called when the user clicks an action button
+ */
+export const renderJobList = (
+    jobs: JobClient[],
+    states: Map<number, JobState>,
+    onAction: (job: JobClient, input: string) => void
+): void => {
+    const list = jobListEl();
+    list.textContent = "";
+
+    if (jobs.length === 0) {
+        renderEmptyState();
+        return;
+    }
+
+    for (const job of jobs) {
+        const state = states.get(job.id) ?? STATE_QUEUED;
+        const card = createJobCard(job, state, onAction);
+        list.appendChild(card);
+    }
+};
+
+/**
+ * Update a single job card in-place — avoids full list re-render on tick events.
+ * Replaces the card's DOM node with a freshly rendered one for the updated state.
+ *
+ * If the card doesn't exist yet (e.g., first render), this is a no-op — the
+ * next renderJobList call will create it.
+ */
+export const updateJobCard = (
+    job: JobClient,
+    state: JobState,
+    onAction: (job: JobClient, input: string) => void
+): void => {
+    const list = jobListEl();
+    const existing = list.querySelector(`[data-job-id="${job.id}"]`);
+
+    if (!existing) {
+        // Job hasn't been rendered yet — nothing to update
+        return;
+    }
+
+    const updated = createJobCard(job, state, onAction);
+    list.replaceChild(updated, existing);
+};
+
+/**
+ * Show the empty state placeholder when there are no jobs.
+ */
+export const renderEmptyState = (): void => {
+    const list = jobListEl();
+    list.textContent = "";
+
+    const empty = document.createElement("div");
+    empty.className = "empty-state";
+
+    const msg = document.createElement("p");
+    msg.className = "empty-state__message";
+    msg.textContent = "No jobs yet. Click Add Job to create one.";
+    empty.appendChild(msg);
+
+    const hint = document.createElement("p");
+    hint.className = "empty-state__hint";
+    hint.textContent = "Start a job and then refresh the page to see rehydrate() in action.";
+    empty.appendChild(hint);
+
+    list.appendChild(empty);
+};
+
+/**
+ * Show the restored-from-storage banner at the top of the page.
+ * The banner auto-dismisses after 6 seconds.
+ *
+ * @param count - Number of jobs restored from localStorage
+ */
+export const renderRestoredBanner = (count: number): void => {
+    const banner = getEl<HTMLDivElement>("restored-banner");
+    const text = getEl<HTMLSpanElement>("restored-banner-text");
+
+    text.textContent =
+        count === 1
+            ? "1 job restored from localStorage."
+            : `${count} jobs restored from localStorage.`;
+
+    banner.hidden = false;
+
+    // Auto-dismiss so it doesn't linger forever
+    const dismiss = () => {
+        banner.hidden = true;
+    };
+
+    setTimeout(dismiss, 6000);
+
+    // Also dismiss on click
+    banner.addEventListener("click", dismiss, { once: true });
+};
+
+/**
+ * Wire the "Add Job" button. Returns a cleanup function to remove the listener.
+ */
+export const initAddJobButton = (onClick: () => void): (() => void) => {
+    const btn = addJobBtnEl();
+    btn.addEventListener("click", onClick);
+    return () => btn.removeEventListener("click", onClick);
+};
+
+/**
+ * Wire the "Clear Storage" button. Returns a cleanup function.
+ */
+export const initClearStorageButton = (onClick: () => void): (() => void) => {
+    const btn = getEl<HTMLButtonElement>("btn-clear-storage");
+    btn.addEventListener("click", onClick);
+    return () => btn.removeEventListener("click", onClick);
+};
+
+/**
+ * Enable or disable the "Add Job" button based on whether the job cap is reached.
+ * Called whenever a job is added or removed.
+ */
+export const setAddJobEnabled = (enabled: boolean): void => {
+    const btn = addJobBtnEl();
+    btn.disabled = !enabled;
+    btn.title = enabled ? "" : `Maximum of ${MAX_JOBS} jobs reached.`;
+};

--- a/examples/job-queue/tsconfig.json
+++ b/examples/job-queue/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "useDefineForClassFields": true,
+        "lib": ["ES2022", "DOM", "DOM.Iterable"],
+        "module": "ESNext",
+        "skipLibCheck": true,
+        "moduleResolution": "bundler",
+        "allowImportingTsExtensions": true,
+        "isolatedModules": true,
+        "moduleDetection": "force",
+        "noEmit": true,
+        "strict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noFallthroughCasesInSwitch": true
+    },
+    "include": ["src"]
+}

--- a/examples/job-queue/tsconfig.test.json
+++ b/examples/job-queue/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "module": "CommonJS",
+        "moduleResolution": "node",
+        "lib": ["ES2022", "DOM", "DOM.Iterable"],
+        "allowSyntheticDefaultImports": true,
+        "noEmit": true,
+        "strict": true,
+        "skipLibCheck": true
+    },
+    "include": ["src/**/*"]
+}

--- a/examples/job-queue/vite.config.ts
+++ b/examples/job-queue/vite.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vite";
+import { umami } from "../vite-plugin-umami";
+import { workspaceSource } from "../vite-plugin-workspace-source";
+
+export default defineConfig({
+    plugins: [umami(), workspaceSource()],
+    base: process.env.VITE_BASE_PATH || "/",
+});

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
         "*.json": "prettier --write"
     },
     "devDependencies": {
-        "@apogeelabs/the-agency": "0.4.0",
+        "@apogeelabs/the-agency": "0.11.0",
         "@changesets/cli": "^2.30.0",
         "@eslint/js": "^9.39.2",
         "@types/jest": "^30.0.0",

--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -99,6 +99,7 @@ export default defineConfig({
                         { slug: "examples/traffic-intersection" },
                         { slug: "examples/dungeon-critters" },
                         { slug: "examples/shopping-cart" },
+                        { slug: "examples/job-queue" },
                         { slug: "examples/with-react" },
                         { slug: "examples/machina-explorer" },
                     ],

--- a/packages/docs/src/content/docs/examples/job-queue.mdx
+++ b/packages/docs/src/content/docs/examples/job-queue.mdx
@@ -1,0 +1,104 @@
+---
+title: Job Queue
+description: Persist/restore pattern using BehavioralFsm rehydrate() with localStorage.
+---
+
+import { LinkCard } from "@astrojs/starlight/components";
+
+A simulated job queue where multiple jobs share a single `BehavioralFsm` definition, state is auto-persisted to localStorage on every transition, and a page refresh restores all jobs via `rehydrate()`. The centerpiece teaching moment: `rehydrate()` is silent — `_onEnter` doesn't fire — so the app must explicitly re-establish side effects (timers) for in-flight jobs.
+
+<LinkCard title="Run the Job Queue" href="/demos/job-queue/" target="_blank" />
+
+## What it demonstrates
+
+- **`rehydrate()` for silent state restoration** — place a client at a saved state without triggering `_onEnter`, `_onExit`, or any events. The WeakMap entry is written as if the client had always been there.
+- **Two-step restore: rehydrate + resume** — after `rehydrate()` places a job in `processing`, the app dispatches `resume` to restart the tick timer. This is the canonical pattern for recovering side effects after a cold restore.
+- **`createBehavioralFsm` with per-client state** — one FSM definition drives all jobs. Each job is a plain object; state lives in the FSM's internal WeakMap, not on the client.
+- **localStorage persistence on every transition** — the `transitioned` event handler serializes all jobs and their states. State is stored alongside the client, not on it, matching the `rehydrate()` API's design.
+
+## States
+
+```
+                start                          tick (all steps done)
+  queued ──────────────► processing ──────────────────────────► completed
+                           │    ▲
+                     pause │    │ resume
+                           ▼    │
+                          paused
+                           │
+                     tick (random failure)
+                           ▼
+                          failed
+                           │
+                     retry │ (resets currentStep)
+                           ▼
+                        processing
+```
+
+| State        | What happens                                                                                                                   |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| `queued`     | Registered but not running. `start` transitions to `processing`.                                                               |
+| `processing` | Tick timer advances `currentStep`. Random failure chance on each tick. `pause` stops the timer. `resume` restarts it silently. |
+| `paused`     | Timer stopped. `resume` transitions back to `processing`, firing `_onEnter` to restart the timer.                              |
+| `failed`     | Something went wrong during a tick. `retry` resets `currentStep` to 0 and transitions to `processing` for a fresh run.         |
+| `completed`  | Terminal. Job reached `totalSteps`. No inputs handled.                                                                         |
+
+## The rehydrate pattern
+
+On page load, `main.ts` reads localStorage and restores each job in two steps:
+
+```ts
+// STEP 1: Silent placement — no _onEnter, no events, no timer
+fsm.rehydrate(job, savedState);
+
+// STEP 2: Re-establish side effects for in-flight jobs
+if (savedState === "processing") {
+    fsm.handle(job, "resume");
+}
+```
+
+The `resume` handler on `processing` restarts the tick timer without transitioning — the job stays in `processing` and picks up where it left off. This dual meaning of `resume` is intentional:
+
+- **From `paused`**: `resume` transitions to `processing`, which fires `_onEnter` and starts the timer normally.
+- **While in `processing`**: `resume` restarts the timer in-place. No transition, no events beyond `handling`/`handled`. This is the post-rehydrate path.
+
+## Persistence design
+
+State is persisted alongside the client, not on it. The serialized shape stores `state` as a sibling field:
+
+```ts
+interface PersistedJob {
+    state: JobState; // from fsm.currentState(job)
+    id: number;
+    name: string;
+    currentStep: number;
+    totalSteps: number;
+    createdAt: string;
+    // timer is excluded — setTimeout handles are not serializable
+}
+```
+
+This matches the `rehydrate()` API: `fsm.rehydrate(client, state)` takes state as a separate argument because BehavioralFsm stores state in a WeakMap, not on the client object.
+
+On deserialization, `timer` is set to `null`. The `resume` input re-establishes it for processing jobs.
+
+## Stale storage recovery
+
+`rehydrate()` throws synchronously for unknown state names. `main.ts` wraps the restore loop in `try/catch` — if a schema change makes old data incompatible, it clears localStorage and starts fresh rather than crashing:
+
+```ts
+try {
+    for (const persisted of shape.jobs) {
+        const job = reconstructClient(persisted);
+        fsm.rehydrate(job, persisted.state);
+        // ...
+    }
+} catch {
+    // rehydrate() threw — state names changed since last save
+    localStorage.removeItem(STORAGE_KEY);
+}
+```
+
+## Source
+
+[examples/job-queue/](https://github.com/ifandelse/machina.js/tree/master/examples/job-queue)

--- a/packages/docs/src/content/docs/examples/overview.mdx
+++ b/packages/docs/src/content/docs/examples/overview.mdx
@@ -3,7 +3,7 @@ title: Examples Overview
 description: Runnable example applications demonstrating machina patterns.
 ---
 
-machina ships with seven runnable examples covering real-world patterns — from async health checks to React integration to test suite patterns. Each one is a self-contained app you can run locally, and on the deployed docs site they're live at their own routes.
+machina ships with eight runnable examples covering real-world patterns — from async health checks to React integration to test suite patterns. Each one is a self-contained app you can run locally, and on the deployed docs site they're live at their own routes.
 
 ## Examples
 
@@ -13,6 +13,7 @@ machina ships with seven runnable examples covering real-world patterns — from
 | [Traffic Intersection](/examples/traffic-intersection/) | Hierarchical traffic light controller with pedestrian signals           | `_child` delegation, `compositeState()`, input bubbling, `defer()`, child auto-reset    |
 | [Dungeon Critters](/examples/dungeon-critters/)         | Multiple critter instances sharing one FSM definition                   | `createBehavioralFsm`, per-client state via `WeakMap`, shared behavior definition       |
 | [Shopping Cart](/examples/shopping-cart/)               | Checkout flow with deferred operations                                  | `createFsm`, `defer()`, `defer({ until })`, lifecycle hooks                             |
+| [Job Queue](/examples/job-queue/)                       | Persist/restore pattern with `rehydrate()` and localStorage             | `createBehavioralFsm`, `rehydrate()`, silent state restoration, side-effect recovery    |
 | [With React](/examples/with-react/)                     | React integration for a todo app                                        | `createFsm`, `useSyncExternalStore`, framework integration                              |
 | [machina-explorer](/examples/machina-explorer/)         | Interactive FSM inspector and state diagram visualizer                  | `buildStateGraph`, `inspectGraph`, mermaid `stateDiagram-v2`, CodeMirror 6              |
 | Testing with machina-test                               | Graph matchers, hierarchical FSM testing, and `walkAll` runtime testing | `machina-test` matchers, `walkAll`, payload generators, seed replay                     |
@@ -33,6 +34,6 @@ pnpm --filter @machina-examples/connectivity dev
 cd examples/connectivity && pnpm dev
 ```
 
-Swap `connectivity` for any of the example names: `traffic-intersection`, `dungeon-critters`, `shopping-cart`, `with-react`, `machina-explorer`, or `testing-with-machina-test`.
+Swap `connectivity` for any of the example names: `traffic-intersection`, `dungeon-critters`, `shopping-cart`, `job-queue`, `with-react`, `machina-explorer`, or `testing-with-machina-test`.
 
 The `testing-with-machina-test` example is test-only (no Vite dev server) — run it with `pnpm --filter @machina-examples/testing-with-machina-test test`.

--- a/packages/docs/src/content/docs/guide/behavioral-fsm.mdx
+++ b/packages/docs/src/content/docs/guide/behavioral-fsm.mdx
@@ -100,6 +100,12 @@ parentFsm.rehydrate(client, "active.uploading.retrying");
     grab the state value to persist with your client, use the latter to restore.
 </Aside>
 
+<Aside type="note">
+    The [Job Queue example](/examples/job-queue/) demonstrates the full persist/restore cycle —
+    serializing state to localStorage on every transition and cold-resuming jobs via `rehydrate()`
+    after a page reload.
+</Aside>
+
 ## Events
 
 `BehavioralFsm` emits the same lifecycle events as `Fsm`. The difference is every payload includes a `client` field so you can identify which client the event pertains to:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@apogeelabs/the-agency':
-        specifier: 0.4.0
-        version: 0.4.0
+        specifier: 0.11.0
+        version: 0.11.0
       '@changesets/cli':
         specifier: ^2.30.0
         version: 2.30.0(@types/node@25.2.3)
@@ -128,6 +128,31 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+
+  examples/job-queue:
+    dependencies:
+      machina:
+        specifier: workspace:*
+        version: link:../../packages/machina
+    devDependencies:
+      '@types/jest':
+        specifier: ^30.0.0
+        version: 30.0.0
+      eslint:
+        specifier: ^9.39.4
+        version: 9.39.4
+      jest:
+        specifier: ^30.3.0
+        version: 30.3.0(@types/node@25.2.3)(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.6
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.2.3)(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^6.3.5
+        version: 6.4.1(@types/node@25.2.3)(tsx@4.21.0)(yaml@2.8.2)
 
   examples/machina-explorer:
     dependencies:
@@ -418,8 +443,8 @@ packages:
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
-  '@apogeelabs/the-agency@0.4.0':
-    resolution: {integrity: sha512-CfzV2rsGNHNKGLB5rI0xN3sneZKQ8G/AWGznNQV+MuYYZ3nppHu5/qJylgM9iCgFrklHCwcJ2DLQbZ/c5wRNlQ==}
+  '@apogeelabs/the-agency@0.11.0':
+    resolution: {integrity: sha512-k8KHrBaeX66ZdbN2kcdehAxhEghxmCz2cUgA8rK8PND9Ol9nlvL6GW20jAcOAd00bG7RirTq9nEtxra2Qia44Q==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -5721,7 +5746,7 @@ snapshots:
       package-manager-detector: 1.6.0
       tinyexec: 1.0.2
 
-  '@apogeelabs/the-agency@0.4.0':
+  '@apogeelabs/the-agency@0.11.0':
     dependencies:
       prompts: 2.4.2
 


### PR DESCRIPTION
# feat(examples): add job-queue rehydrate() showcase

**Branch**: rehydrate-example → master
**Changes**: 2,734 additions, 8 deletions across 22 files

---

## Summary

### New `examples/job-queue/` — BehavioralFsm rehydrate() demo

machina v6 shipped `rehydrate()` on BehavioralFsm but had zero runnable examples showing the persist/restore pattern. This PR fills that gap — a conference-quality job queue demo that makes the two-step restore pattern (rehydrate + resume) immediately visible and understandable.

The key teaching moment: `rehydrate()` is intentionally silent (no `_onEnter`, no events), so the *app* owns re-establishing side effects. For in-flight jobs, that means dispatching `resume` after rehydrate to restart the tick timer.

**What's included:**
1. Full example app: `config.ts`, `fsm.ts`, `main.ts`, `ui.ts`, `style.css`, `index.html` with project scaffolding
2. 30 tests in `fsm.test.ts` covering state transitions, timer lifecycle, rehydrate silent placement, rehydrate + resume, boundary cases, and multi-job independence
3. Documentation: new `job-queue.mdx` docs page, updated examples overview (7 → 8), cross-reference in `behavioral-fsm.mdx` guide, `README.md` entry
4. `@apogeelabs/the-agency` bumped from 0.4.0 → 0.11.0

---

## Risk Callouts

- **`@apogeelabs/the-agency` 0.4.0 → 0.11.0** — significant semver gap for a pre-1.0 package. Confirm compatibility.
- **`any` typing in `fsm.ts`** — the `let instance` pattern for timer closures uses `any` to sidestep circular type inference. Functional but loses type safety on the FSM reference inside timer closures.
- **Dead CSS** — leftover `::after` pseudo-element styles on `.job-card__progress-bar` appear superseded by the `.job-card__progress-fill` child element approach. Cosmetic only.

---

## Tribal Knowledge Checks

### General Checks

- [x] **New environment variables**: None
- [x] **Type safety**: Two `any` usages in `fsm.ts` with eslint-disable for timer closure pattern. Test file uses `any` (example code, not library)
- [x] **Dead code**: All exports consumed
- [x] **Dependency changes**: Example devDeps consistent with monorepo. Agency bump noted above
- [x] **Leftover debugging**: `console.debug` in main.ts is intentional (matches other examples)
- [x] **Breaking interface changes**: None — all changes are additive
- [x] **Large binary/asset additions**: None

### Unit Test Checks

- [x] **Style guide adherence**: Follows Critical Rules # 1 and # 2 (execution in `beforeEach`, mocks in `beforeEach`)
- [x] **Test descriptions match assertions**: All `it` descriptions match `expect` statements
- [x] **`export default {}`**: Present

---

## Testing Recommendations

### Manual Verification

- **Full persist/restore cycle**: Add 3-4 jobs at different states → refresh → verify correct restoration with "restored" badges and auto-resumed timers
- **Clear Storage contrast**: Restore jobs → Clear Storage → refresh → verify empty queue
- **Stale storage recovery**: Manually corrupt localStorage data → reload → verify graceful recovery
- **20-job cap**: Add jobs until "Add Job" button disables

### Automated Test Gaps

- FSM covered thoroughly (30 tests). `main.ts`/`ui.ts` untested by design (consistent with other examples)

### Regression Risks

- Verify `pnpm run checks` passes at root level (agency version bump)
- Verify `pnpm --filter docs build` succeeds (new sidebar entry, MDX page)