### PR TITLE
Add BehavioralFsm client persistence (dehydrate/rehydrate)

### DIFF
--- a/.changeset/client-persistence.md
+++ b/.changeset/client-persistence.md
@@ -1,0 +1,5 @@
+---
+"machina": minor
+---
+
+Add `dehydrate(client)` and a snapshot-aware overload of `rehydrate(client, snapshot)` to `BehavioralFsm`. `dehydrate()` returns a plain, JSON-serializable snapshot of everything machina tracks for a client — current state, pending deferred inputs, and the same for every `_child` in the hierarchy, active or not. The object form of `rehydrate()` restores it, requeuing deferrals at every level with no lifecycle hooks or events, so a restored client behaves identically to one that never left memory. The existing string form of `rehydrate()` (composite-state-only, no deferrals) is unchanged. Throws for an Fsm child on the client's active path (consistent with the existing string-form `rehydrate()` throw) — an off-path Fsm child elsewhere in the hierarchy, no matter how deeply nested under other `BehavioralFsm` children, is skipped rather than blocking `dehydrate()` for clients that never reach it. Also throws for deferred arguments that can't survive a serialization boundary — the error names the exact input, its `until` target, and the offending value's path.

--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -109,6 +109,7 @@ export default defineConfig({
                         { slug: "guide/hierarchical" },
                         { slug: "guide/events" },
                         { slug: "guide/defer" },
+                        { slug: "guide/persisting-clients" },
                     ],
                 },
                 typeDocSidebarGroup,

--- a/packages/docs/src/content/docs/guide/behavioral-fsm.mdx
+++ b/packages/docs/src/content/docs/guide/behavioral-fsm.mdx
@@ -46,9 +46,10 @@ Every method takes the client object as its first argument. The rest of the API 
 | `currentState(client)`               | Returns the client's current state, or `undefined` if never initialized |
 | `compositeState(client)`             | Dot-delimited path including active child FSM states                    |
 | `rehydrate(client, compositeState)`  | Silently place a client at a state — no lifecycle hooks or events       |
+| `dehydrate(client)`                  | Snapshot everything tracked for a client — state, deferrals, children   |
+| `rehydrate(client, snapshot)`        | Restore a `dehydrate()` snapshot — state and deferred queues, no hooks  |
 | `on(eventName, callback)`            | Subscribe to a lifecycle event — returns `{ off() }`                    |
 | `emit(eventName, data?)`             | Emit a custom event to subscribers                                      |
-| `dispose(client, options?)`          | Dispose a single client's state entry                                   |
 | `dispose()`                          | Permanently shut down the entire FSM; cascades to child FSMs by default |
 
 <Aside type="note">
@@ -96,9 +97,35 @@ parentFsm.rehydrate(client, "active.uploading.retrying");
 `rehydrate()` throws synchronously on invalid state names or structural mismatches (missing `_child`, Fsm children). Writes are atomic — if validation fails at any level of a composite path, no state is written at any level.
 
 <Aside type="tip">
-    `compositeState()` produces the dot-path string that `rehydrate()` consumes. Use the former to
-    grab the state value to persist with your client, use the latter to restore.
+    `compositeState()` produces the dot-path string that this string form of `rehydrate()` consumes.
+    Use the former to grab the state value to persist with your client, use the latter to restore.
 </Aside>
+
+### Snapshots: persisting deferred inputs too
+
+The string form above only captures the composite state — it drops anything sitting in a client's deferred queue. If a client can have pending deferrals when it gets persisted, use `dehydrate()` and the object form of `rehydrate()` instead. `dehydrate()` returns a plain, JSON-serializable snapshot of everything machina tracks for a client — current state, pending deferred inputs (with their args and `until` targets), and the same for every `_child` in the hierarchy, active or not:
+
+```ts
+// ---- Persist ----
+const snapshot = connFsm.dehydrate(theClient);
+// { state: "connecting", deferred: [{ inputName: "retry", args: [], untilState: "online" }] }
+await db.save(JSON.stringify(snapshot));
+
+// ---- Restore (possibly a different process) ----
+const snapshot = JSON.parse(await db.load());
+connFsm.rehydrate(theClient, snapshot); // silent placement, deferrals requeued
+connFsm.handle(theClient, "connected"); // "retry" replays once "online" is reached
+```
+
+`dehydrate()` returns `undefined` for a client the FSM has never seen — it does not trigger initialization, mirroring `currentState()`. It throws if any deferred input's arguments contain something that can't survive a serialization boundary (a function, `undefined`, a `Date`/`Map`/class instance, a symbol, `NaN`/`Infinity`, or a circular reference) — the error names the exact input, its `until` target if any, and the precise path to the offending value.
+
+<Aside type="caution">
+    `dehydrate()` is for a client **at rest** between `handle()` calls, not from inside a handler —
+    the in-flight arguments for a currently-executing input aren't part of the snapshot. Call it
+    after your service layer's `handle()` call returns, right before persisting.
+</Aside>
+
+Both the string and object forms of `rehydrate()` place the client silently — no `_onEnter`, no `_onExit`, no `transitioning`/`transitioned` events — and both validate the entire hierarchy before writing anything, at any level. The object form additionally requeues each level's deferred inputs so they replay exactly as they would have if the client had never left memory. For hierarchical FSMs, `dehydrate()` walks every state's `_child` recursively, including states the client currently isn't in — a child left mid-flight when the parent moved on is captured too, so its pending `_onExit`/`_onEnter` and deferred replay behavior on the parent's next re-entry survives the round trip. See [Persisting clients](/guide/persisting-clients/) for the full repository/service pattern.
 
 <Aside type="note">
     The [Job Queue example](/examples/job-queue/) demonstrates the full persist/restore cycle —

--- a/packages/docs/src/content/docs/guide/persisting-clients.mdx
+++ b/packages/docs/src/content/docs/guide/persisting-clients.mdx
@@ -1,0 +1,94 @@
+---
+title: Persisting clients
+description: A repository pattern for saving and restoring BehavioralFsm client state, deferrals included.
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+`BehavioralFsm` tracks per-client state internally in a `WeakMap` — nothing is stamped onto the client object, and the engine is entirely synchronous with no storage concept of its own. That's deliberate: machina doesn't know about your database, and it never performs I/O. `dehydrate()` and `rehydrate()` are the seam — they turn "everything machina knows about a client" into plain data and back, so your application's repository layer can own the actual load and save.
+
+## The repository pattern
+
+Keep persistence in one place: a repository that knows how to fetch a client and its FSM snapshot together, and save them back together in a single atomic write.
+
+```ts
+class CartRepository {
+    async getCart(id: string): Promise<Cart> {
+        const row = await redis.get(`cart:${id}`);
+        const cart = deserializeCart(row.cart);
+        cartFsm.rehydrate(cart, row.fsm); // silent placement, deferrals requeued
+        return cart;
+    }
+
+    async saveCart(cart: Cart): Promise<void> {
+        const fsm = cartFsm.dehydrate(cart); // throws here if defer args can't persist
+        await redis.set(`cart:${cart.id}`, { cart: serializeCart(cart), fsm }); // one atomic write
+    }
+}
+```
+
+Two things make this work cleanly:
+
+- **`dehydrate()` throws at save time**, not at some later point during deserialization. If a handler deferred an input with a non-serializable argument, you find out immediately, with an error naming the exact input and value path — not after a restart, staring at corrupted state.
+- **One write, one transaction.** The client's business data and its FSM state are saved together. There's no window where one could be persisted without the other.
+
+## The service bracket: explicit load → handle → save
+
+Machina's API is entirely synchronous — `handle()` never awaits anything. Async work (fetching, saving) belongs in the layer that calls into the FSM, not inside it. A service method owns the full bracket explicitly:
+
+```ts
+async function checkout(id: string) {
+    const cart = await repo.getCart(id); // load
+    cartFsm.handle(cart, "checkout"); // core API, synchronous, untouched
+    await repo.saveCart(cart); // save
+}
+```
+
+This bracket — load, handle, save — is the whole pattern. There's no hidden middleware, no implicit persistence hook on `transitioned`. You decide exactly when a save happens, which makes the failure modes obvious: if `saveCart` throws, the in-memory `cart` object already reflects the new state, but nothing durable changed. Retry the save, or re-fetch and re-apply, same as any other transactional write.
+
+## Snapshots and deferred inputs
+
+`compositeState()` + the string form of `rehydrate()` cover clients that never defer anything — a state name is the whole story. Once deferred inputs are in play, that's not enough: a deferred input sitting in the queue when a client is saved needs to survive the round trip too, or it silently vanishes on restore.
+
+`dehydrate()` returns everything machina tracks for a client as a plain, nested object — mirroring the FSM hierarchy for clients with child FSMs:
+
+```ts
+const snapshot = cartFsm.dehydrate(cart);
+// {
+//   state: "validating",
+//   deferred: [{ inputName: "applyDiscount", args: ["WELCOME10"], untilState: "checkout" }],
+// }
+```
+
+Restoring is the object form of `rehydrate()` — same silent-placement contract as the string form (no `_onEnter`, no `_onExit`, no events), plus the deferred queue gets requeued at every level:
+
+```ts
+cartFsm.rehydrate(cart, snapshot);
+cartFsm.handle(cart, "advance"); // proceeds normally; "applyDiscount" replays once "checkout" is reached
+```
+
+For hierarchical FSMs, the walk is full-fidelity: `dehydrate()` captures every state whose `_child` has ever seen the client, not just the one the client is currently in. A child the parent left mid-flight — powered on, mid-retry, whatever — is captured under its declaring state name and restored the same way. That matters because leaving a child's state isn't the same as resetting it: the child stays exactly where it was until the parent re-enters that state, at which point the reset transition fires the child's stale `_onExit`, then `_onEnter` (skipped if the child was already at its `initialState`), then replays anything still in that child's deferred queue. A restored client reproduces all of that identically — it's indistinguishable from one that never left memory.
+
+<Aside type="caution">
+    **Dehydrate at rest, not mid-handler.** Call `dehydrate()` after a `handle()` call returns —
+    from your service layer's save step — never from inside a handler. The arguments for a
+    currently-executing input aren't part of a client's persisted state; they only exist for the
+    duration of that one `handle()` call.
+</Aside>
+
+<Aside type="note">
+    `dehydrate()` throws if a deferred input's arguments contain anything that can't survive
+    serialization — a function, `undefined`, a `Date`/`Map`/class instance, a symbol,
+    `NaN`/`Infinity`, or a circular reference. Keep deferred arguments to plain data (strings,
+    numbers, booleans, plain objects/arrays, `null`) and this never comes up.
+</Aside>
+
+## What machina doesn't do
+
+- **No storage I/O.** `dehydrate()`/`rehydrate()` hand you plain data; where it lives — Redis, Postgres, a file, a message queue — is entirely your call.
+- **No identity keying.** Client state is tracked by object reference (`WeakMap`), not by an ID machina manages. The snapshot travels _with_ your client through the repository, so this works correctly under horizontal scaling by construction — there's no server-affinity requirement, no shared session store to keep in sync.
+- **No async API.** `handle()`, `transition()`, `rehydrate()`, and `dehydrate()` are all synchronous. This is load-bearing, not an oversight — it's what keeps the state machine's own logic simple and testable. Async lives in the bracket around it.
+
+## A note on concurrent requests
+
+None of the above prevents two concurrent requests for the _same_ client from racing: both load a snapshot, both handle an input against their own in-memory copy, both save — and the second save silently clobbers the first. Machina has no opinion on this because it's an application architecture problem, not an FSM problem. If a given client can receive concurrent requests, route them through a single-writer discipline — a consistent-hash-routed worker, a per-entity mailbox/actor, a database-level lock on the save — so that `load → handle → save` runs as a serialized sequence for that entity. That discipline lives entirely in your service layer; it has nothing to do with machina's API.

--- a/packages/docs/src/content/docs/guide/persisting-clients.mdx
+++ b/packages/docs/src/content/docs/guide/persisting-clients.mdx
@@ -14,23 +14,24 @@ Keep persistence in one place: a repository that knows how to fetch a client and
 ```ts
 class CartRepository {
     async getCart(id: string): Promise<Cart> {
-        const row = await redis.get(`cart:${id}`);
-        const cart = deserializeCart(row.cart);
-        cartFsm.rehydrate(cart, row.fsm); // silent placement, deferrals requeued
+        const row = await store.carts.get(id); // { cart, fsm } — parsed however your storage parses
+        const cart = deserializeCart(row.cart); // revive YOUR object — Dates, class instances, etc.
+        cartFsm.rehydrate(cart, row.fsm); // silent placement, deferrals requeued — no revival needed
         return cart;
     }
 
     async saveCart(cart: Cart): Promise<void> {
         const fsm = cartFsm.dehydrate(cart); // throws here if defer args can't persist
-        await redis.set(`cart:${cart.id}`, { cart: serializeCart(cart), fsm }); // one atomic write
+        await store.carts.put(cart.id, { cart: serializeCart(cart), fsm }); // one atomic write
     }
 }
 ```
 
-Two things make this work cleanly:
+Three things make this work cleanly:
 
 - **`dehydrate()` throws at save time**, not at some later point during deserialization. If a handler deferred an input with a non-serializable argument, you find out immediately, with an error naming the exact input and value path — not after a restart, staring at corrupted state.
 - **One write, one transaction.** The client's business data and its FSM state are saved together. There's no window where one could be persisted without the other.
+- **`rehydrate()` takes the parsed object.** Whether your driver hands you parsed documents (MongoDB, Postgres `jsonb`) or strings you `JSON.parse` yourself (raw Redis) is your storage layer's concern. The snapshot is guaranteed JSON-safe plain data, so it passes through any of those boundaries unchanged — only _your_ object may need revival, which is what `deserializeCart` stands in for. If your client is plain data too, it collapses to nothing.
 
 ## The service bracket: explicit load → handle → save
 
@@ -81,6 +82,15 @@ For hierarchical FSMs, the walk is full-fidelity: `dehydrate()` captures every s
     serialization — a function, `undefined`, a `Date`/`Map`/class instance, a symbol,
     `NaN`/`Infinity`, or a circular reference. Keep deferred arguments to plain data (strings,
     numbers, booleans, plain objects/arrays, `null`) and this never comes up.
+</Aside>
+
+<Aside type="tip">
+    **Why JSON-safe when your database can store more?** MongoDB's BSON will happily round-trip a
+    `Date` — and `dehydrate()` still throws on one. That's deliberate. The snapshot contract is the
+    lowest common denominator, so a snapshot stays portable across every storage and can never
+    silently lose fidelity on the ones that only speak JSON. Storage-specific rich types would tie
+    persisted state to one backend and reintroduce exactly the silent-mangling problem `dehydrate()`
+    exists to prevent.
 </Aside>
 
 ## What machina doesn't do

--- a/packages/machina/src/behavioral-fsm.test.ts
+++ b/packages/machina/src/behavioral-fsm.test.ts
@@ -3193,3 +3193,1664 @@ describe("BehavioralFsm — rehydrate()", () => {
         });
     });
 });
+
+// =============================================================================
+// Exploratory: in-memory reset/replay oracle for off-path children
+//
+// These tests exercise ONLY existing engine behavior (handle/transition) —
+// no dehydrate()/rehydrate() involved. They pin down what happens, purely
+// in-memory, when a parent re-enters a state whose child was left in a
+// non-initial state with a pending deferral. That behavior is the oracle a
+// round-tripped (dehydrate → rehydrate) client must reproduce exactly for
+// "restored is indistinguishable from never-left-memory" to hold.
+//
+// Run/read these BEFORE the dehydrate()/rehydrate(snapshot) suites below.
+// =============================================================================
+
+describe("BehavioralFsm — child reset/replay oracle (exploratory, in-memory only)", () => {
+    describe("when the parent re-enters a state whose child left a non-initial state", () => {
+        let parent: any, child: any, client: ChildClient, childExitedFrom: string;
+
+        beforeEach(() => {
+            childExitedFrom = "";
+            child = createBehavioralFsm({
+                id: "oracle-child",
+                initialState: "off",
+                states: {
+                    off: { poweron: "on" },
+                    on: {
+                        _onExit() {
+                            childExitedFrom = "on";
+                        },
+                        poweroff: "off",
+                    },
+                },
+            });
+            parent = createBehavioralFsm({
+                id: "oracle-parent",
+                initialState: "idle",
+                states: {
+                    idle: { activate: "active" },
+                    active: { _child: child, deactivate: "idle" },
+                },
+            });
+            client = {};
+            parent.handle(client, "activate"); // idle → active, child resets to off (no-op, already off)
+            child.handle(client, "poweron"); // child: off → on
+            parent.handle(client, "deactivate"); // active → idle — child left "on", now off-path
+            parent.handle(client, "activate"); // idle → active again — child reset fires stale on:_onExit
+        });
+
+        it("should fire the stale state's _onExit during the reset transition", () => {
+            expect(childExitedFrom).toBe("on");
+        });
+
+        it("should land the child back at its initialState", () => {
+            expect(child.currentState(client)).toBe("off");
+        });
+    });
+
+    describe("when the off-path child has a deferred input targeting its initialState", () => {
+        let parent: any, child: any, client: ChildClient, pingReplayed: boolean;
+
+        beforeEach(() => {
+            pingReplayed = false;
+            child = createBehavioralFsm({
+                id: "oracle-defer-child",
+                initialState: "off",
+                states: {
+                    off: {
+                        poweron: "on",
+                        ping() {
+                            pingReplayed = true;
+                        },
+                    },
+                    on: {
+                        poweroff: "off",
+                        ping({ defer }: any) {
+                            defer({ until: "off" });
+                        },
+                    },
+                },
+            });
+            parent = createBehavioralFsm({
+                id: "oracle-defer-parent",
+                initialState: "idle",
+                states: {
+                    idle: { activate: "active" },
+                    active: { _child: child, deactivate: "idle" },
+                },
+            });
+            client = {};
+            parent.handle(client, "activate"); // idle → active, child resets to off
+            child.handle(client, "poweron"); // child: off → on
+            child.handle(client, "ping"); // deferred until "off"
+            parent.handle(client, "deactivate"); // active → idle — child left "on" with a pending deferral
+            parent.handle(client, "activate"); // idle → active — child reset (on → off) replays "ping"
+        });
+
+        it("should replay the deferred input on the reset transition", () => {
+            expect(pingReplayed).toBe(true);
+        });
+
+        it("should end up at the child's initialState after replay", () => {
+            expect(child.currentState(client)).toBe("off");
+        });
+    });
+
+    // Same-state reset no-op (skipping _onEnter) is already pinned by the
+    // "child reset when child is already in initialState on re-entry" suite
+    // above — not duplicated here.
+});
+
+// =============================================================================
+// dehydrate() tests
+// =============================================================================
+
+describe("BehavioralFsm — dehydrate()", () => {
+    describe("flat FSM, no deferrals", () => {
+        let fsm: any, client: ChildClient, snapshot: any;
+
+        beforeEach(() => {
+            fsm = createBehavioralFsm({
+                id: "dehydrate-flat",
+                initialState: "idle",
+                states: {
+                    idle: { start: "running" },
+                    running: {},
+                },
+            });
+            client = {};
+            fsm.handle(client, "start"); // idle → running
+            snapshot = fsm.dehydrate(client);
+        });
+
+        it("should return the state and an empty deferred queue with no children entry", () => {
+            expect(snapshot).toEqual({ state: "running", deferred: [] });
+        });
+    });
+
+    describe("when the client has never been seen", () => {
+        let fsm: any, result: any;
+
+        beforeEach(() => {
+            fsm = createBehavioralFsm({
+                id: "dehydrate-never-seen",
+                initialState: "idle",
+                states: { idle: {}, running: {} },
+            });
+            result = fsm.dehydrate({});
+        });
+
+        it("should return undefined", () => {
+            expect(result).toBeUndefined();
+        });
+
+        it("should not initialize the client as a side effect", () => {
+            const client = {};
+            fsm.dehydrate(client);
+            expect(fsm.currentState(client)).toBeUndefined();
+        });
+    });
+
+    describe("pending deferrals — untargeted and targeted", () => {
+        let fsm: any, client: ChildClient, snapshot: any;
+
+        beforeEach(() => {
+            fsm = createBehavioralFsm({
+                id: "dehydrate-deferred",
+                initialState: "idle",
+                states: {
+                    idle: {
+                        wait({ defer }: any) {
+                            defer();
+                        },
+                        save({ defer }: any) {
+                            defer({ until: "archived" });
+                        },
+                        start: "running",
+                    },
+                    running: {},
+                    archived: {},
+                },
+            });
+            client = {};
+            fsm.handle(client, "wait", "kirk");
+            fsm.handle(client, "save", { id: 8675309 });
+            snapshot = fsm.dehydrate(client);
+        });
+
+        it("should capture both deferred inputs with inputName, args, and untilState", () => {
+            expect(snapshot).toEqual({
+                state: "idle",
+                deferred: [
+                    { inputName: "wait", args: ["kirk"] },
+                    { inputName: "save", args: [{ id: 8675309 }], untilState: "archived" },
+                ],
+            });
+        });
+    });
+
+    describe("non-serializable deferred args", () => {
+        describe("when an untargeted deferred input has a function arg", () => {
+            let fsm: any, client: ChildClient, thrownError: Error | undefined;
+
+            beforeEach(() => {
+                fsm = createBehavioralFsm({
+                    id: "cart",
+                    initialState: "browsing",
+                    states: {
+                        browsing: {
+                            retry({ defer }: any) {
+                                defer();
+                            },
+                        },
+                    },
+                });
+                client = {};
+                fsm.handle(client, "retry", "ignored", { onComplete: () => "boom" });
+                try {
+                    fsm.dehydrate(client);
+                } catch (e: any) {
+                    thrownError = e;
+                }
+            });
+
+            it("should throw naming the input, the FSM id, and the exact value path", () => {
+                expect(thrownError).toBeDefined();
+                expect(thrownError!.message).toBe(
+                    'dehydrate: deferred input "retry" in FSM "cart" has a non-serializable ' +
+                        "value at args[1].onComplete (function)"
+                );
+            });
+        });
+
+        describe("when a targeted deferred input has a circular reference", () => {
+            let fsm: any, client: ChildClient, thrownError: Error | undefined;
+
+            beforeEach(() => {
+                const circular: Record<string, unknown> = { name: "Cal Zone" };
+                circular.self = circular;
+                fsm = createBehavioralFsm({
+                    id: "cart",
+                    initialState: "browsing",
+                    states: {
+                        browsing: {
+                            retry({ defer }: any) {
+                                defer({ until: "connected" });
+                            },
+                        },
+                    },
+                });
+                client = {};
+                fsm.handle(client, "retry", circular);
+                try {
+                    fsm.dehydrate(client);
+                } catch (e: any) {
+                    thrownError = e;
+                }
+            });
+
+            it("should include the until-target in the error message", () => {
+                expect(thrownError).toBeDefined();
+                expect(thrownError!.message).toBe(
+                    'dehydrate: deferred input "retry" (until "connected") in FSM "cart" ' +
+                        "has a non-serializable value at args[0].self (circular reference)"
+                );
+            });
+        });
+    });
+
+    describe("deeply nested plain objects/arrays/null pass the walk", () => {
+        let fsm: any, client: ChildClient, snapshot: any, payload: Record<string, unknown>;
+
+        beforeEach(() => {
+            payload = {
+                name: "Cal Zone",
+                tags: ["geeky", null, "playful"],
+                address: { city: "Springfield", nested: { deep: [1, 2, { ok: true }] } },
+            };
+            fsm = createBehavioralFsm({
+                id: "dehydrate-nested",
+                initialState: "idle",
+                states: {
+                    idle: {
+                        wait({ defer }: any) {
+                            defer();
+                        },
+                    },
+                },
+            });
+            client = {};
+            fsm.handle(client, "wait", payload);
+            snapshot = fsm.dehydrate(client);
+        });
+
+        it("should clone the nested structure without throwing", () => {
+            expect(snapshot.deferred[0].args[0]).toEqual(payload);
+        });
+    });
+
+    describe("hierarchy — nested snapshot across 3 levels", () => {
+        let grandchild: any, childFsm: any, grandparent: any, client: ChildClient, snapshot: any;
+
+        beforeEach(() => {
+            grandchild = createBehavioralFsm({
+                id: "dehydrate-gc",
+                initialState: "alpha",
+                states: {
+                    alpha: { next: "beta" },
+                    beta: {
+                        hold({ defer }: any) {
+                            defer();
+                        },
+                    },
+                },
+            });
+            childFsm = createBehavioralFsm({
+                id: "dehydrate-child",
+                initialState: "x",
+                states: {
+                    x: { _child: grandchild, jump: "y" },
+                    y: {},
+                },
+            });
+            grandparent = createBehavioralFsm({
+                id: "dehydrate-gp",
+                initialState: "top",
+                states: {
+                    top: { _child: childFsm },
+                },
+            });
+            client = {};
+            grandparent.handle(client, "noop" as any); // init cascades: top → x → alpha
+            grandchild.handle(client, "next"); // alpha → beta
+            grandchild.handle(client, "hold"); // defer "hold", untargeted, while in beta
+            snapshot = grandparent.dehydrate(client);
+        });
+
+        it("should produce a fully nested snapshot matching the active hierarchy", () => {
+            expect(snapshot).toEqual({
+                state: "top",
+                deferred: [],
+                children: {
+                    top: {
+                        state: "x",
+                        deferred: [],
+                        children: {
+                            x: {
+                                state: "beta",
+                                deferred: [{ inputName: "hold", args: [] }],
+                            },
+                        },
+                    },
+                },
+            });
+        });
+    });
+
+    describe("off-path child meta", () => {
+        let child: any, parent: any, client: ChildClient, snapshot: any;
+
+        beforeEach(() => {
+            child = createBehavioralFsm({
+                id: "dehydrate-offpath-child",
+                initialState: "off",
+                states: {
+                    off: { poweron: "on" },
+                    on: {
+                        poweroff: "off",
+                        ping({ defer }: any) {
+                            defer({ until: "off" });
+                        },
+                    },
+                },
+            });
+            parent = createBehavioralFsm({
+                id: "dehydrate-offpath-parent",
+                initialState: "idle",
+                states: {
+                    idle: { activate: "active" },
+                    active: { _child: child, deactivate: "idle" },
+                },
+            });
+            client = {};
+            parent.handle(client, "activate"); // idle → active, child resets to off
+            child.handle(client, "poweron"); // child: off → on
+            child.handle(client, "ping"); // deferred until "off"
+            parent.handle(client, "deactivate"); // active → idle — child now off-path
+            snapshot = parent.dehydrate(client);
+        });
+
+        it("should capture the parent's own state as idle with no deferrals", () => {
+            expect(snapshot.state).toBe("idle");
+            expect(snapshot.deferred).toEqual([]);
+        });
+
+        it("should capture the off-path child's state and pending deferral under its declaring state", () => {
+            expect(snapshot.children).toEqual({
+                active: {
+                    state: "on",
+                    deferred: [{ inputName: "ping", args: [], untilState: "off" }],
+                },
+            });
+        });
+    });
+
+    describe("shared child instance under two parent states", () => {
+        let child: any, parent: any, client: ChildClient, snapshot: any, dehydrateSpy: jest.Mock;
+
+        beforeEach(() => {
+            child = createBehavioralFsm({
+                id: "dehydrate-shared-child",
+                initialState: "off",
+                states: {
+                    off: { poweron: "on" },
+                    on: {},
+                },
+            });
+            parent = createBehavioralFsm({
+                id: "dehydrate-shared-parent",
+                initialState: "modeA",
+                states: {
+                    modeA: { _child: child, switch: "modeB" },
+                    modeB: { _child: child },
+                },
+            });
+            client = {};
+            parent.handle(client, "noop" as any); // init → modeA, child resets to off
+            child.handle(client, "poweron"); // child: off → on
+
+            // Wrap child.dehydrate() (an own-property override, not jest.spyOn —
+            // this codebase doesn't use spyOn) so we can verify the dedup cache
+            // actually prevents a second walk of the shared child's subtree.
+            // Output equality alone can't distinguish "dedup'd" from "walked
+            // twice, got the same answer both times."
+            const originalDehydrate = child.dehydrate.bind(child);
+            dehydrateSpy = jest.fn((c: ChildClient) => originalDehydrate(c));
+            child.dehydrate = dehydrateSpy;
+
+            snapshot = parent.dehydrate(client);
+        });
+
+        it("should emit one identical snapshot under both declaring state names", () => {
+            expect(snapshot.children.modeA).toEqual({ state: "on", deferred: [] });
+            expect(snapshot.children.modeB).toEqual({ state: "on", deferred: [] });
+        });
+
+        it("should dehydrate the shared child instance only once", () => {
+            expect(dehydrateSpy).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("Fsm child on the active path", () => {
+        let fsm: any, thrownError: Error | undefined;
+
+        beforeEach(() => {
+            const fsmChild = createFsm({
+                id: "dehydrate-fsm-child",
+                initialState: "on",
+                states: {
+                    on: { poweroff: "off" },
+                    off: { poweron: "on" },
+                },
+            });
+            fsm = createBehavioralFsm({
+                id: "dehydrate-fsm-parent",
+                initialState: "active",
+                states: {
+                    active: { _child: fsmChild as any },
+                },
+            });
+            const client = {};
+            fsm.handle(client, "noop" as any); // init
+            try {
+                fsm.dehydrate(client);
+            } catch (e: any) {
+                thrownError = e;
+            }
+        });
+
+        it("should throw, consistent with rehydrate()", () => {
+            expect(thrownError).toBeDefined();
+            expect(thrownError!.message).toContain("cannot dehydrate an Fsm child");
+        });
+    });
+
+    describe("Fsm child on a never-visited branch", () => {
+        let fsm: any,
+            safeClient: ChildClient,
+            riskyClient: ChildClient,
+            safeSnapshot: any,
+            thrownError: Error | undefined;
+
+        beforeEach(() => {
+            const fsmChild = createFsm({
+                id: "dehydrate-offpath-fsm-child",
+                initialState: "on",
+                states: {
+                    on: { poweroff: "off" },
+                    off: { poweron: "on" },
+                },
+            });
+            fsm = createBehavioralFsm({
+                id: "dehydrate-offpath-fsm-parent",
+                initialState: "idle",
+                states: {
+                    idle: { go: "running", detour: "weird" },
+                    running: {},
+                    weird: { _child: fsmChild as any },
+                },
+            });
+
+            safeClient = {};
+            fsm.handle(safeClient, "go"); // idle → running; "weird" never touched
+
+            riskyClient = {};
+            fsm.handle(riskyClient, "detour"); // idle → weird; Fsm child now on-path
+
+            safeSnapshot = fsm.dehydrate(safeClient);
+            try {
+                fsm.dehydrate(riskyClient);
+            } catch (e: any) {
+                thrownError = e;
+            }
+        });
+
+        it("should not throw for a client that never touched the Fsm-child branch", () => {
+            expect(safeSnapshot).toEqual({ state: "running", deferred: [] });
+        });
+
+        it("should still throw for a client actually on the Fsm-child branch", () => {
+            expect(thrownError).toBeDefined();
+            expect(thrownError!.message).toContain("cannot dehydrate an Fsm child");
+        });
+    });
+
+    describe("Fsm grandchild nested under an off-path BehavioralFsm child", () => {
+        let parent: any, client: ChildClient, snapshot: any, thrownError: Error | undefined;
+
+        beforeEach(() => {
+            const fsmChild = createFsm({
+                id: "dehydrate-nested-fsm-leaf",
+                initialState: "leafA",
+                states: {
+                    leafA: { go: "leafB" },
+                    leafB: {},
+                },
+            });
+            const midChild = createBehavioralFsm({
+                id: "dehydrate-nested-mid",
+                initialState: "midInit",
+                states: {
+                    midInit: { go: "midActive" },
+                    midActive: { _child: fsmChild as any },
+                },
+            });
+            parent = createBehavioralFsm({
+                id: "dehydrate-nested-parent",
+                initialState: "start",
+                states: {
+                    start: { go: "branch" },
+                    branch: { _child: midChild as any, leave: "elsewhere" },
+                    elsewhere: {},
+                },
+            });
+
+            client = {};
+            parent.handle(client, "go"); // start -> branch; mid resets to midInit
+            parent.handle(client, "go"); // delegates to mid: midInit -> midActive (declares the Fsm leaf)
+            parent.handle(client, "leave"); // branch -> elsewhere; mid is now off-path, frozen at midActive
+
+            try {
+                snapshot = parent.dehydrate(client);
+            } catch (e: any) {
+                thrownError = e;
+            }
+        });
+
+        it("should not throw even though the frozen mid child sits at its Fsm-declaring state", () => {
+            expect(thrownError).toBeUndefined();
+        });
+
+        it("should still capture the off-path mid child's own state", () => {
+            expect(snapshot).toEqual({
+                state: "elsewhere",
+                deferred: [],
+                children: {
+                    branch: {
+                        state: "midActive",
+                        deferred: [],
+                    },
+                },
+            });
+        });
+    });
+
+    describe("Fsm grandchild nested under an actively-traversed BehavioralFsm child", () => {
+        let parent: any, client: ChildClient, thrownError: Error | undefined;
+
+        beforeEach(() => {
+            const fsmChild = createFsm({
+                id: "dehydrate-nested-active-fsm-leaf",
+                initialState: "leafA",
+                states: {
+                    leafA: { go: "leafB" },
+                    leafB: {},
+                },
+            });
+            const midChild = createBehavioralFsm({
+                id: "dehydrate-nested-active-mid",
+                initialState: "midInit",
+                states: {
+                    midInit: { go: "midActive" },
+                    midActive: { _child: fsmChild as any },
+                },
+            });
+            parent = createBehavioralFsm({
+                id: "dehydrate-nested-active-parent",
+                initialState: "start",
+                states: {
+                    start: { go: "branch" },
+                    branch: { _child: midChild as any, leave: "elsewhere" },
+                    elsewhere: {},
+                },
+            });
+
+            client = {};
+            parent.handle(client, "go"); // start -> branch; mid resets to midInit
+            parent.handle(client, "go"); // delegates to mid: midInit -> midActive (declares the Fsm leaf)
+            // No "leave" — the client stays on the branch, so mid (and its Fsm leaf) is live.
+
+            try {
+                parent.dehydrate(client);
+            } catch (e: any) {
+                thrownError = e;
+            }
+        });
+
+        it("should still throw when the branch is actually being traversed", () => {
+            expect(thrownError).toBeDefined();
+            expect(thrownError!.message).toContain("cannot dehydrate an Fsm child");
+        });
+    });
+
+    describe("shared BehavioralFsm child declaring an Fsm leaf, non-active declaring name listed first", () => {
+        let parent: any,
+            client: ChildClient,
+            activeComposite: string,
+            thrownError: Error | undefined;
+
+        beforeEach(() => {
+            const leaf = createFsm({
+                id: "dehydrate-shared-order-leaf",
+                initialState: "leafA",
+                states: { leafA: { go: "leafB" }, leafB: {} },
+            });
+            const child = createBehavioralFsm({
+                id: "dehydrate-shared-order-child",
+                initialState: "off",
+                states: {
+                    off: { poweron: "hot" },
+                    hot: { _child: leaf as any },
+                },
+            });
+            // "modeB" (never entered by this client) is declared BEFORE "modeA"
+            // (the client's genuinely active state) in the object literal.
+            parent = createBehavioralFsm({
+                id: "dehydrate-shared-order-parent-b-first",
+                initialState: "modeA",
+                states: {
+                    modeB: { _child: child as any },
+                    modeA: { _child: child as any, leave: "modeB" },
+                },
+            });
+
+            client = {};
+            parent.handle(client, "noop" as any); // init -> modeA
+            child.handle(client, "poweron"); // child: off -> hot (declares the Fsm leaf)
+            activeComposite = parent.compositeState(client);
+
+            try {
+                parent.dehydrate(client);
+            } catch (e: any) {
+                thrownError = e;
+            }
+        });
+
+        it("should confirm the client is genuinely active on the Fsm-leaf branch", () => {
+            expect(activeComposite).toBe("modeA.hot.leafA");
+        });
+
+        it("should throw for the genuinely active client even though its declaring name iterates second", () => {
+            expect(thrownError).toBeDefined();
+            expect(thrownError!.message).toContain("cannot dehydrate an Fsm child");
+        });
+    });
+
+    describe("shared BehavioralFsm child declaring an Fsm leaf, active declaring name listed first", () => {
+        let parent: any,
+            client: ChildClient,
+            activeComposite: string,
+            thrownError: Error | undefined;
+
+        beforeEach(() => {
+            const leaf = createFsm({
+                id: "dehydrate-shared-order-leaf",
+                initialState: "leafA",
+                states: { leafA: { go: "leafB" }, leafB: {} },
+            });
+            const child = createBehavioralFsm({
+                id: "dehydrate-shared-order-child",
+                initialState: "off",
+                states: {
+                    off: { poweron: "hot" },
+                    hot: { _child: leaf as any },
+                },
+            });
+            // "modeA" (the client's genuinely active state) is declared BEFORE
+            // "modeB" (never entered by this client) — the mirror ordering of
+            // the sibling scenario above, guarding against the fix only
+            // happening to work for one iteration order.
+            parent = createBehavioralFsm({
+                id: "dehydrate-shared-order-parent-a-first",
+                initialState: "modeA",
+                states: {
+                    modeA: { _child: child as any, leave: "modeB" },
+                    modeB: { _child: child as any },
+                },
+            });
+
+            client = {};
+            parent.handle(client, "noop" as any); // init -> modeA
+            child.handle(client, "poweron"); // child: off -> hot (declares the Fsm leaf)
+            activeComposite = parent.compositeState(client);
+
+            try {
+                parent.dehydrate(client);
+            } catch (e: any) {
+                thrownError = e;
+            }
+        });
+
+        it("should confirm the client is genuinely active on the Fsm-leaf branch", () => {
+            expect(activeComposite).toBe("modeA.hot.leafA");
+        });
+
+        it("should throw for the genuinely active client when its declaring name iterates first", () => {
+            expect(thrownError).toBeDefined();
+            expect(thrownError!.message).toContain("cannot dehydrate an Fsm child");
+        });
+    });
+
+    describe("shared BehavioralFsm child declaring an Fsm leaf, client off-path at both declaring states", () => {
+        let snapshot: any, dehydrateSpy: jest.Mock, thrownError: Error | undefined;
+
+        beforeEach(() => {
+            const leaf = createFsm({
+                id: "dehydrate-shared-order-leaf",
+                initialState: "leafA",
+                states: { leafA: { go: "leafB" }, leafB: {} },
+            });
+            const child = createBehavioralFsm({
+                id: "dehydrate-shared-order-child",
+                initialState: "off",
+                states: {
+                    off: { poweron: "hot" },
+                    hot: { _child: leaf as any },
+                },
+            });
+            const parent = createBehavioralFsm({
+                id: "dehydrate-shared-order-parent-offpath",
+                initialState: "modeA",
+                states: {
+                    modeB: { _child: child as any },
+                    modeA: { _child: child as any, leave: "modeC" },
+                    modeC: {},
+                },
+            });
+
+            const client: ChildClient = {};
+            parent.handle(client, "noop" as any); // init -> modeA
+            child.handle(client, "poweron"); // child: off -> hot (declares the Fsm leaf)
+            parent.handle(client, "leave"); // modeA -> modeC; neither declaring name is active anymore
+
+            // Wrap child.dehydrate() the same way the existing dedup test does,
+            // so the call count can't be faked by "walked twice, same answer".
+            const originalDehydrate = child.dehydrate.bind(child);
+            dehydrateSpy = jest.fn((c: ChildClient, onPath?: boolean) =>
+                originalDehydrate(c, onPath)
+            );
+            child.dehydrate = dehydrateSpy;
+
+            try {
+                snapshot = parent.dehydrate(client);
+            } catch (e: any) {
+                thrownError = e;
+            }
+        });
+
+        it("should not throw even though the shared child sits at its Fsm-declaring state", () => {
+            expect(thrownError).toBeUndefined();
+        });
+
+        it("should capture the shared child's own state under both declaring names, without the off-path Fsm leaf", () => {
+            expect(snapshot).toEqual({
+                state: "modeC",
+                deferred: [],
+                children: {
+                    modeA: { state: "hot", deferred: [] },
+                    modeB: { state: "hot", deferred: [] },
+                },
+            });
+        });
+
+        it("should dehydrate the shared child instance only once", () => {
+            expect(dehydrateSpy).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("snapshot mutation after dehydrate", () => {
+        let fsm: any, client: ChildClient, snapshot: any, originalPayload: Record<string, unknown>;
+
+        beforeEach(() => {
+            originalPayload = { count: 1 };
+            fsm = createBehavioralFsm({
+                id: "dehydrate-mutation",
+                initialState: "idle",
+                states: {
+                    idle: {
+                        wait({ defer }: any) {
+                            defer();
+                        },
+                    },
+                },
+            });
+            client = {};
+            fsm.handle(client, "wait", originalPayload);
+            snapshot = fsm.dehydrate(client);
+
+            // Mutate the RETURNED snapshot — this must not reach back into the
+            // FSM's internal deferred queue (the walk clones, it doesn't alias).
+            snapshot.deferred[0].args[0].count = 12345;
+        });
+
+        it("should not reflect the snapshot mutation in a fresh dehydrate() call", () => {
+            const freshSnapshot = fsm.dehydrate(client);
+            expect(freshSnapshot.deferred[0].args[0]).toEqual({ count: 1 });
+        });
+    });
+});
+
+// =============================================================================
+// rehydrate(snapshot) — object form
+// =============================================================================
+
+describe("BehavioralFsm — rehydrate(snapshot) object form", () => {
+    describe("flat snapshot with deferred inputs", () => {
+        let fsm: any, client: ChildClient, transitioningCb: jest.Mock, handledCb: jest.Mock;
+
+        beforeEach(() => {
+            transitioningCb = jest.fn();
+            handledCb = jest.fn();
+            fsm = createBehavioralFsm({
+                id: "rehydrate-snapshot-flat",
+                initialState: "idle",
+                states: {
+                    idle: { start: "running" },
+                    running: { advance: "done" },
+                    // Untargeted defer replays against the state entered by the NEXT
+                    // transition, not the one it was queued from — so "ping" lives here.
+                    done: {
+                        ping() {
+                            handledCb();
+                        },
+                    },
+                },
+            });
+            client = {};
+            fsm.on("transitioning", transitioningCb);
+            fsm.rehydrate(client, {
+                state: "running",
+                deferred: [{ inputName: "ping", args: [] }],
+            });
+        });
+
+        it("should place the client at the snapshotted state", () => {
+            expect(fsm.currentState(client)).toBe("running");
+        });
+
+        it("should not fire any lifecycle events during placement", () => {
+            expect(transitioningCb).not.toHaveBeenCalled();
+        });
+
+        it("should replay the requeued deferred input after the next transition", () => {
+            fsm.handle(client, "advance"); // running → done, then replays "ping" in "done"
+            expect(handledCb).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("mutating the snapshot's nested deferred args after rehydrate() returns", () => {
+        let fsm: any,
+            client: ChildClient,
+            nestedPayload: Record<string, unknown>,
+            snapshotAfterMutation: any,
+            replayedArgs: unknown[];
+
+        beforeEach(() => {
+            nestedPayload = { count: 1 };
+            replayedArgs = [];
+            fsm = createBehavioralFsm({
+                id: "rehydrate-snapshot-alias",
+                initialState: "idle",
+                states: {
+                    idle: { start: "running" },
+                    running: { advance: "done" },
+                    // Targeted defer (until "done") stays queued across the
+                    // "running" state so we can dehydrate() BEFORE it replays.
+                    done: {
+                        ping(_args: any, ...rest: unknown[]) {
+                            replayedArgs = rest;
+                        },
+                    },
+                },
+            });
+            client = {};
+            fsm.rehydrate(client, {
+                state: "running",
+                deferred: [{ inputName: "ping", args: [nestedPayload], untilState: "done" }],
+            });
+
+            // Mutate the CALLER'S object after rehydrate() returns — this must not
+            // reach into the FSM's internal deferred queue (the write must clone,
+            // not alias, item.args).
+            nestedPayload.count = 999;
+
+            snapshotAfterMutation = fsm.dehydrate(client);
+            fsm.handle(client, "advance"); // running → done, replays "ping" (untilState "done")
+        });
+
+        it("should not reflect the post-rehydrate mutation in a fresh dehydrate() snapshot", () => {
+            expect(snapshotAfterMutation.deferred).toEqual([
+                { inputName: "ping", args: [{ count: 1 }], untilState: "done" },
+            ]);
+        });
+
+        it("should replay the deferred input with the original, unmutated args", () => {
+            expect(replayedArgs).toEqual([{ count: 1 }]);
+        });
+    });
+
+    describe("invalid state name at the top level", () => {
+        let fsm: any, thrownError: Error | undefined;
+
+        beforeEach(() => {
+            fsm = createBehavioralFsm({
+                id: "rehydrate-snapshot-invalid-top",
+                initialState: "idle",
+                states: { idle: {}, running: {} },
+            });
+            try {
+                fsm.rehydrate({}, { state: "nonexistent", deferred: [] });
+            } catch (e: any) {
+                thrownError = e;
+            }
+        });
+
+        it("should throw naming the bad state and the FSM id", () => {
+            expect(thrownError).toBeDefined();
+            expect(thrownError!.message).toContain("nonexistent");
+            expect(thrownError!.message).toContain("rehydrate-snapshot-invalid-top");
+        });
+    });
+
+    describe("invalid state name at a nested level — atomicity", () => {
+        let child: any, parent: any, client: ChildClient, thrownError: Error | undefined;
+
+        beforeEach(() => {
+            child = createBehavioralFsm({
+                id: "rehydrate-snapshot-nested-child",
+                initialState: "off",
+                states: { off: {}, on: {} },
+            });
+            parent = createBehavioralFsm({
+                id: "rehydrate-snapshot-nested-parent",
+                initialState: "idle",
+                states: {
+                    idle: {},
+                    active: { _child: child },
+                },
+            });
+            client = {};
+            try {
+                parent.rehydrate(client, {
+                    state: "active",
+                    deferred: [],
+                    children: { active: { state: "bogus", deferred: [] } },
+                });
+            } catch (e: any) {
+                thrownError = e;
+            }
+        });
+
+        it("should throw naming the bad nested state", () => {
+            expect(thrownError).toBeDefined();
+            expect(thrownError!.message).toContain("bogus");
+        });
+
+        it("should leave the parent unwritten (nothing written anywhere)", () => {
+            expect(parent.currentState(client)).toBeUndefined();
+        });
+
+        it("should leave the child unwritten", () => {
+            expect(child.currentState(client)).toBeUndefined();
+        });
+    });
+
+    describe("children entry referencing a state with no _child", () => {
+        let fsm: any, thrownError: Error | undefined;
+
+        beforeEach(() => {
+            fsm = createBehavioralFsm({
+                id: "rehydrate-snapshot-no-child",
+                initialState: "idle",
+                states: { idle: {}, running: {} },
+            });
+            try {
+                fsm.rehydrate(
+                    {},
+                    {
+                        state: "running",
+                        deferred: [],
+                        children: { running: { state: "sub", deferred: [] } },
+                    }
+                );
+            } catch (e: any) {
+                thrownError = e;
+            }
+        });
+
+        it("should throw naming the state and the FSM id", () => {
+            expect(thrownError).toBeDefined();
+            expect(thrownError!.message).toContain("running");
+            expect(thrownError!.message).toContain("rehydrate-snapshot-no-child");
+        });
+    });
+
+    describe("children entry referencing a stateName that isn't declared at all", () => {
+        let fsm: any, thrownError: Error | undefined;
+
+        beforeEach(() => {
+            fsm = createBehavioralFsm({
+                id: "rehydrate-snapshot-unknown-child-key",
+                initialState: "idle",
+                states: { idle: {}, running: {} },
+            });
+            try {
+                fsm.rehydrate(
+                    {},
+                    {
+                        state: "running",
+                        deferred: [],
+                        children: { bogusState: { state: "sub", deferred: [] } },
+                    }
+                );
+            } catch (e: any) {
+                thrownError = e;
+            }
+        });
+
+        it("should throw naming the unknown state and the FSM id", () => {
+            expect(thrownError).toBeDefined();
+            expect(thrownError!.message).toContain("bogusState");
+            expect(thrownError!.message).toContain("rehydrate-snapshot-unknown-child-key");
+        });
+    });
+
+    describe("nested child FSM instance is disposed independently of the parent", () => {
+        let child: any, parent: any, client: ChildClient;
+
+        beforeEach(() => {
+            child = createBehavioralFsm({
+                id: "rehydrate-snapshot-disposed-child",
+                initialState: "off",
+                states: { off: {}, on: {} },
+            });
+            parent = createBehavioralFsm({
+                id: "rehydrate-snapshot-parent-of-disposed-child",
+                initialState: "idle",
+                states: {
+                    idle: {},
+                    active: { _child: child },
+                },
+            });
+            client = {};
+            child.dispose();
+            parent.rehydrate(client, {
+                state: "active",
+                deferred: [],
+                children: { active: { state: "on", deferred: [] } },
+            });
+        });
+
+        it("should not throw and should still rehydrate the parent", () => {
+            expect(parent.currentState(client)).toBe("active");
+        });
+
+        it("should silently skip writing to the disposed child", () => {
+            expect(child.currentState(client)).toBeUndefined();
+        });
+    });
+
+    describe("Fsm child referenced by a snapshot's children entry", () => {
+        let parent: any, thrownError: Error | undefined;
+
+        beforeEach(() => {
+            const fsmChild = createFsm({
+                id: "rehydrate-snapshot-fsm-child",
+                initialState: "on",
+                states: { on: {}, off: {} },
+            });
+            parent = createBehavioralFsm({
+                id: "rehydrate-snapshot-fsm-parent",
+                initialState: "active",
+                states: {
+                    active: { _child: fsmChild as any },
+                },
+            });
+            try {
+                parent.rehydrate(
+                    {},
+                    {
+                        state: "active",
+                        deferred: [],
+                        children: { active: { state: "off", deferred: [] } },
+                    }
+                );
+            } catch (e: any) {
+                thrownError = e;
+            }
+        });
+
+        it("should throw, consistent with the string form", () => {
+            expect(thrownError).toBeDefined();
+            expect(thrownError!.message).toContain("cannot rehydrate an Fsm child");
+        });
+    });
+
+    describe("shared child instance referenced under two state keys", () => {
+        let child: any, parent: any, client: ChildClient;
+
+        beforeEach(() => {
+            child = createBehavioralFsm({
+                id: "rehydrate-snapshot-shared-child",
+                initialState: "off",
+                states: { off: {}, on: {} },
+            });
+            parent = createBehavioralFsm({
+                id: "rehydrate-snapshot-shared-parent",
+                initialState: "modeA",
+                states: {
+                    modeA: { _child: child },
+                    modeB: { _child: child },
+                },
+            });
+            client = {};
+            parent.rehydrate(client, {
+                state: "modeA",
+                deferred: [],
+                children: {
+                    modeA: { state: "on", deferred: [] },
+                    modeB: { state: "on", deferred: [] },
+                },
+            });
+        });
+
+        it("should place the shared child idempotently despite two duplicate write thunks", () => {
+            expect(child.currentState(client)).toBe("on");
+        });
+
+        it("should place the parent at the snapshotted state", () => {
+            expect(parent.currentState(client)).toBe("modeA");
+        });
+    });
+
+    describe("disposed FSM", () => {
+        let fsm: any, client: ChildClient;
+
+        beforeEach(() => {
+            fsm = createBehavioralFsm({
+                id: "rehydrate-snapshot-disposed",
+                initialState: "idle",
+                states: { idle: {}, running: {} },
+            });
+            client = {};
+            fsm.dispose();
+            fsm.rehydrate(client, { state: "running", deferred: [] });
+        });
+
+        it("should be a no-op", () => {
+            expect(fsm.currentState(client)).toBeUndefined();
+        });
+    });
+
+    describe("equivalence with the string form when deferred is empty", () => {
+        let child: any, parent: any, stringClient: ChildClient, objectClient: ChildClient;
+
+        beforeEach(() => {
+            child = createBehavioralFsm({
+                id: "equivalence-child",
+                initialState: "off",
+                states: { off: { poweron: "on" }, on: { poweroff: "off" } },
+            });
+            parent = createBehavioralFsm({
+                id: "equivalence-parent",
+                initialState: "idle",
+                states: {
+                    idle: {},
+                    active: { _child: child },
+                },
+            });
+            stringClient = {};
+            objectClient = {};
+            parent.rehydrate(stringClient, "active.on");
+            parent.rehydrate(objectClient, {
+                state: "active",
+                deferred: [],
+                children: { active: { state: "on", deferred: [] } },
+            });
+        });
+
+        it("should place both clients in the same parent state", () => {
+            expect(parent.currentState(objectClient)).toBe(parent.currentState(stringClient));
+        });
+
+        it("should place both clients in the same child state", () => {
+            expect(child.currentState(objectClient)).toBe(child.currentState(stringClient));
+        });
+
+        it("should produce the same compositeState for both", () => {
+            expect(parent.compositeState(objectClient)).toBe(parent.compositeState(stringClient));
+        });
+    });
+});
+
+// =============================================================================
+// Full persistence round-trip: dehydrate → JSON round-trip → rehydrate
+// =============================================================================
+
+describe("BehavioralFsm — persistence round-trip", () => {
+    describe("hierarchy with an off-path deferral, restored onto a NEW client object", () => {
+        let child: any,
+            parent: any,
+            originalClient: ChildClient,
+            newClient: ChildClient,
+            pingReplayed: boolean,
+            transitioningCb: jest.Mock;
+
+        beforeEach(() => {
+            pingReplayed = false;
+            transitioningCb = jest.fn();
+            child = createBehavioralFsm({
+                id: "roundtrip-child",
+                initialState: "off",
+                states: {
+                    off: {
+                        poweron: "on",
+                        ping() {
+                            pingReplayed = true;
+                        },
+                    },
+                    on: {
+                        poweroff: "off",
+                        ping({ defer }: any) {
+                            defer({ until: "off" });
+                        },
+                    },
+                },
+            });
+            parent = createBehavioralFsm({
+                id: "roundtrip-parent",
+                initialState: "idle",
+                states: {
+                    idle: { activate: "active" },
+                    active: { _child: child, deactivate: "idle" },
+                },
+            });
+
+            // Build up state on the ORIGINAL client: leave the child off-path,
+            // on, with a deferral pending.
+            originalClient = {};
+            parent.handle(originalClient, "activate"); // idle → active, child resets to off
+            child.handle(originalClient, "poweron"); // child: off → on
+            child.handle(originalClient, "ping"); // deferred until "off"
+            parent.handle(originalClient, "deactivate"); // active → idle — child now off-path
+
+            const snapshot = parent.dehydrate(originalClient);
+            const roundTripped = JSON.parse(JSON.stringify(snapshot));
+
+            newClient = {};
+            parent.on("transitioning", transitioningCb);
+            parent.rehydrate(newClient, roundTripped);
+        });
+
+        it("should not fire any lifecycle events during placement", () => {
+            expect(transitioningCb).not.toHaveBeenCalled();
+        });
+
+        it("should restore the parent's state on the new client", () => {
+            expect(parent.currentState(newClient)).toBe("idle");
+        });
+
+        it("should restore the off-path child's state on the new client", () => {
+            expect(child.currentState(newClient)).toBe("on");
+        });
+
+        describe("when the new client's parent re-enters the child's state", () => {
+            beforeEach(() => {
+                parent.handle(newClient, "activate"); // idle → active: child resets (on → off), replays "ping"
+            });
+
+            it("should replay the restored deferred input, identical to the in-memory oracle", () => {
+                expect(pingReplayed).toBe(true);
+            });
+
+            it("should land the child at its initialState after replay", () => {
+                expect(child.currentState(newClient)).toBe("off");
+            });
+        });
+
+        it("should leave the original client's live state untouched", () => {
+            expect(parent.currentState(originalClient)).toBe("idle");
+            expect(child.currentState(originalClient)).toBe("on");
+        });
+    });
+});
+
+// =============================================================================
+// Hardening: hostile snapshots, deep/diamond hierarchies, and adversarial
+// call timing that the original test suite's happy-path-plus-error-cases
+// coverage doesn't exercise.
+// =============================================================================
+
+describe("BehavioralFsm — persistence hardening", () => {
+    describe("dehydrate() — shared child instance wired in at two different hierarchy depths", () => {
+        let leaf: any, mid: any, root: any, client: ChildClient, snapshot: any;
+
+        beforeEach(() => {
+            // "leaf" is declared directly under root.branchB AND, two levels
+            // deeper, under mid.midActive (mid is itself root.branchA's child).
+            // Diamond, not a cycle: leaf never declares anything that points
+            // back up toward mid or root.
+            leaf = createBehavioralFsm({
+                id: "diamond-leaf",
+                initialState: "off",
+                states: { off: { poweron: "on" }, on: { poweroff: "off" } },
+            });
+            mid = createBehavioralFsm({
+                id: "diamond-mid",
+                initialState: "midIdle",
+                states: {
+                    midIdle: { go: "midActive" },
+                    midActive: { _child: leaf },
+                },
+            });
+            root = createBehavioralFsm({
+                id: "diamond-root",
+                initialState: "start",
+                states: {
+                    start: { go: "branchA" },
+                    branchA: { _child: mid, hop: "branchB" },
+                    branchB: { _child: leaf },
+                },
+            });
+
+            client = {};
+            root.handle(client, "go"); // start -> branchA; mid resets to midIdle
+            root.handle(client, "go"); // delegates to mid: midIdle -> midActive; leaf resets to off
+            leaf.handle(client, "poweron"); // leaf: off -> on
+
+            snapshot = root.dehydrate(client);
+        });
+
+        it("should capture the shared leaf's state under both tree positions without crashing", () => {
+            expect(snapshot).toEqual({
+                state: "branchA",
+                deferred: [],
+                children: {
+                    branchA: {
+                        state: "midActive",
+                        deferred: [],
+                        children: { midActive: { state: "on", deferred: [] } },
+                    },
+                    branchB: { state: "on", deferred: [] },
+                },
+            });
+        });
+    });
+
+    describe("rehydrate(snapshot) — conflicting states for the same shared child under two declaring keys", () => {
+        let child: any, parent: any, client: ChildClient;
+
+        beforeEach(() => {
+            child = createBehavioralFsm({
+                id: "conflict-shared-child",
+                initialState: "off",
+                states: { off: {}, on: {} },
+            });
+            parent = createBehavioralFsm({
+                id: "conflict-shared-parent",
+                initialState: "modeA",
+                states: {
+                    modeA: { _child: child },
+                    modeB: { _child: child },
+                },
+            });
+            client = {};
+            // A hand-crafted (not dehydrate()-produced) snapshot: the same
+            // child instance is asked to be in two different states at once.
+            // dehydrate() itself can never produce this (its dedup emits one
+            // identical value under every declaring key) — this pins what
+            // happens when the snapshot itself is self-contradictory.
+            parent.rehydrate(client, {
+                state: "modeA",
+                deferred: [],
+                children: {
+                    modeA: { state: "on", deferred: [] },
+                    modeB: { state: "off", deferred: [] },
+                },
+            });
+        });
+
+        it("should resolve to the last-written declaring key's state (modeB, iterated second)", () => {
+            expect(child.currentState(client)).toBe("off");
+        });
+    });
+
+    describe("rehydrate(snapshot) — top-level state name is the inherited '__proto__' accessor", () => {
+        let fsm: any, client: ChildClient, thrownError: Error | undefined;
+
+        beforeEach(() => {
+            thrownError = undefined;
+            fsm = createBehavioralFsm({
+                id: "proto-pollution-state",
+                initialState: "idle",
+                states: { idle: {}, running: {} },
+            });
+            client = {};
+            try {
+                fsm.rehydrate(client, { state: "__proto__", deferred: [] });
+            } catch (e: any) {
+                thrownError = e;
+            }
+        });
+
+        // Regression guard: `state in this.states` was fooled by the inherited
+        // Object.prototype `__proto__` accessor — `"__proto__" in {}` is `true`
+        // even though no state literally named "__proto__" was ever declared
+        // (object-literal syntax can't even create one). planSnapshotWrites()
+        // now uses Object.hasOwn(), which only matches real declared states.
+        it("should throw for the unknown state rather than silently accepting it", () => {
+            expect(thrownError).toBeDefined();
+        });
+    });
+
+    describe("rehydrate(snapshot) — children map key is the inherited '__proto__' accessor", () => {
+        let child: any, fsm: any, client: ChildClient, thrownError: Error | undefined;
+
+        beforeEach(() => {
+            thrownError = undefined;
+            child = createBehavioralFsm({
+                id: "proto-pollution-children-child",
+                initialState: "off",
+                states: { off: {}, on: {} },
+            });
+            fsm = createBehavioralFsm({
+                id: "proto-pollution-children-parent",
+                initialState: "idle",
+                states: { idle: {}, active: { _child: child } },
+            });
+            client = {};
+            // Only JSON.parse (not object-literal syntax) can produce a genuine
+            // OWN "__proto__" property to iterate over via Object.keys().
+            const hostileChildren = JSON.parse('{"__proto__":{"state":"on","deferred":[]}}');
+            try {
+                fsm.rehydrate(client, { state: "active", deferred: [], children: hostileChildren });
+            } catch (e: any) {
+                thrownError = e;
+            }
+        });
+
+        it("should throw rather than write anything, unlike the top-level state field", () => {
+            expect(thrownError).toBeDefined();
+            expect(thrownError!.message).toContain("__proto__");
+        });
+
+        it("should leave the FSM unwritten", () => {
+            expect(fsm.currentState(client)).toBeUndefined();
+        });
+    });
+
+    describe("rehydrate(snapshot) — deferred untilState references a state absent from the definition", () => {
+        let fsm: any, client: ChildClient, pingHandled: boolean;
+
+        beforeEach(() => {
+            pingHandled = false;
+            fsm = createBehavioralFsm({
+                id: "ghost-until-state",
+                initialState: "idle",
+                states: {
+                    idle: { start: "running" },
+                    running: {
+                        ping() {
+                            pingHandled = true;
+                        },
+                    },
+                },
+            });
+            client = {};
+            fsm.rehydrate(client, {
+                state: "idle",
+                deferred: [{ inputName: "ping", args: [], untilState: "ghostState" }],
+            });
+            fsm.handle(client, "start"); // idle -> running; untilState "ghostState" never matches
+        });
+
+        it("should transition normally without replaying the orphaned deferral", () => {
+            expect(fsm.currentState(client)).toBe("running");
+            expect(pingHandled).toBe(false);
+        });
+
+        it("should leave the orphaned deferral sitting inertly in the queue", () => {
+            expect(fsm.dehydrate(client)).toEqual({
+                state: "running",
+                deferred: [{ inputName: "ping", args: [], untilState: "ghostState" }],
+            });
+        });
+    });
+
+    describe("dehydrate() called synchronously from inside a handler, mid-transition", () => {
+        let fsm: any, client: ChildClient, midHandlerSnapshot: any;
+
+        beforeEach(() => {
+            midHandlerSnapshot = undefined;
+            fsm = createBehavioralFsm({
+                id: "dehydrate-mid-handler",
+                initialState: "idle",
+                states: {
+                    idle: {
+                        weird({ defer }: any) {
+                            defer();
+                            // Called before the transition below has happened —
+                            // meta.state is still "idle" at this point.
+                            midHandlerSnapshot = fsm.dehydrate(client);
+                            return "running";
+                        },
+                    },
+                    running: {},
+                },
+            });
+            client = {};
+            fsm.handle(client, "weird");
+        });
+
+        it("should reflect the pre-transition state and the just-deferred input, excluding in-flight handler args", () => {
+            expect(midHandlerSnapshot).toEqual({
+                state: "idle",
+                deferred: [{ inputName: "weird", args: [] }],
+            });
+        });
+
+        it("should leave the FSM's own transition unaffected by the mid-handler dehydrate() call", () => {
+            expect(fsm.currentState(client)).toBe("running");
+        });
+    });
+
+    describe("rehydrate(snapshot) — 3-level nested hierarchy", () => {
+        let grandchild: any, childFsm: any, grandparent: any, client: ChildClient;
+
+        beforeEach(() => {
+            grandchild = createBehavioralFsm({
+                id: "snapshot-3-level-gc",
+                initialState: "alpha",
+                states: { alpha: { next: "beta" }, beta: {} },
+            });
+            childFsm = createBehavioralFsm({
+                id: "snapshot-3-level-child",
+                initialState: "x",
+                states: { x: { _child: grandchild, jump: "y" }, y: {} },
+            });
+            grandparent = createBehavioralFsm({
+                id: "snapshot-3-level-gp",
+                initialState: "top",
+                states: { top: { _child: childFsm } },
+            });
+            client = {};
+            grandparent.rehydrate(client, {
+                state: "top",
+                deferred: [],
+                children: {
+                    top: {
+                        state: "x",
+                        deferred: [],
+                        children: { x: { state: "beta", deferred: [] } },
+                    },
+                },
+            });
+        });
+
+        it("should place every level at its snapshotted state", () => {
+            expect(grandparent.currentState(client)).toBe("top");
+            expect(childFsm.currentState(client)).toBe("x");
+            expect(grandchild.currentState(client)).toBe("beta");
+        });
+
+        it("should produce the full three-level dot-path via compositeState", () => {
+            expect(grandparent.compositeState(client)).toBe("top.x.beta");
+        });
+    });
+
+    describe("dehydrate() on a disposed FSM", () => {
+        let fsm: any, client: ChildClient, snapshot: any;
+
+        beforeEach(() => {
+            fsm = createBehavioralFsm({
+                id: "dehydrate-after-dispose",
+                initialState: "idle",
+                states: { idle: { start: "running" }, running: {} },
+            });
+            client = {};
+            fsm.handle(client, "start");
+            fsm.dispose();
+            snapshot = fsm.dehydrate(client);
+        });
+
+        it("should still return the client's last-known snapshot (dehydrate has no disposed guard, by design)", () => {
+            expect(snapshot).toEqual({ state: "running", deferred: [] });
+        });
+    });
+
+    describe("rehydrate(snapshot) — top-level state name legitimately shadows an inherited Object.prototype member", () => {
+        let fsm: any, client: ChildClient;
+
+        beforeEach(() => {
+            // "hasOwnProperty" IS a real, declared own key here (object-literal
+            // syntax creates it same as any other property name — unlike
+            // "__proto__", there's nothing magic about shadowing an inherited
+            // METHOD name). Object.hasOwn(this.states, "hasOwnProperty") must
+            // still return true for it, exactly as `in` always did — the fix
+            // only needed to stop matching names that are NOT own keys.
+            fsm = createBehavioralFsm({
+                id: "legit-inherited-name-state",
+                initialState: "idle",
+                states: { idle: {}, hasOwnProperty: {} },
+            });
+            client = {};
+            fsm.rehydrate(client, { state: "hasOwnProperty", deferred: [] });
+        });
+
+        it("should accept the declared state rather than rejecting it as if it were inherited", () => {
+            expect(fsm.currentState(client)).toBe("hasOwnProperty");
+        });
+    });
+});

--- a/packages/machina/src/behavioral-fsm.ts
+++ b/packages/machina/src/behavioral-fsm.ts
@@ -9,6 +9,7 @@
 // =============================================================================
 
 import { Emitter, type Subscription } from "./emitter";
+import { cloneDeep, cloneJsonSafe, NonSerializableValueError } from "./json-safe";
 import {
     MACHINA_TYPE,
     type FsmConfig,
@@ -21,6 +22,8 @@ import {
     type DeferredInput,
     type ChildLink,
     type DisposeOptions,
+    type ClientSnapshot,
+    type MachinaInstance,
 } from "./types";
 
 // Safety valve for _onEnter → transition loops. Instance-level counter works
@@ -277,25 +280,176 @@ export class BehavioralFsm<
     }
 
     /**
-     * Silently place `client` at `compositeState` with no lifecycle activity.
+     * Silently place `client` at `compositeState` with no lifecycle activity —
+     * no `_onEnter`, no `_onExit`, no `transitioning`/`transitioned` events.
      * Designed to work with `compositeState()`, which produces the dot-path
-     * string that `rehydrate()` consumes.
+     * string that the string form consumes.
      *
-     * No `_onEnter`, no `_onExit`, no `transitioning`/`transitioned` events.
-     * If `compositeState` is a dot-delimited path (`"active.connecting"`), the client
-     * is placed at each level of the hierarchy in turn. Subsequent `handle()` calls
-     * proceed as if the client had reached that state through normal transitions.
+     * The snapshot form (pass a `ClientSnapshot` from `dehydrate()`) additionally
+     * requeues each level's pending deferred inputs, so a client resumes with the
+     * same replay-on-next-transition behavior it had when dehydrated. Both forms
+     * validate the ENTIRE hierarchy before writing anything — a throw at any level
+     * leaves every level, including this one, unwritten.
      *
-     * Throws synchronously for unknown state names, missing `_child` at an inner level,
-     * or Fsm children in the hierarchy (Fsm owns its context; nothing to rehydrate there).
+     * Throws synchronously for unknown state names, missing `_child` at an inner
+     * level, or Fsm children in the hierarchy (Fsm owns its own context; nothing
+     * per-client to rehydrate there).
      *
      * No-ops silently when disposed.
      */
-    rehydrate(client: TClient, compositeState: string): void {
+    rehydrate(client: TClient, compositeState: string): void;
+    rehydrate(client: TClient, snapshot: ClientSnapshot): void;
+    rehydrate(client: TClient, input: string | ClientSnapshot): void {
         if (this.disposed) {
             return;
         }
 
+        if (typeof input === "string") {
+            this.rehydrateCompositePath(client, input);
+            return;
+        }
+
+        // Object form: collect write thunks for the WHOLE tree first (this level
+        // AND every descendant), then run them only once nothing has thrown.
+        // The string-form's children-first recursion gets atomicity "for free"
+        // because each level writes only after its child already succeeded — but
+        // that couples validation to writing. Here we need every level validated
+        // before ANY level writes, since a leaf failing three levels down must
+        // not leave levels above it holding a stale write.
+        const writes = this.planSnapshotWrites(client, input);
+        for (const write of writes) {
+            write();
+        }
+    }
+
+    /**
+     * Snapshot everything machina tracks for `client`: current state, pending
+     * deferred inputs, and — recursively — the same for every `_child` that has
+     * ever seen this client, active or not. Feed the result to the object form
+     * of `rehydrate()` to restore it later, deferrals included.
+     *
+     * Returns `undefined` for a client this FSM has never seen (mirrors
+     * `currentState()`) — the call does NOT trigger initialization.
+     *
+     * Throws if any deferred input's args contain a non-serializable value
+     * (function, undefined, symbol, bigint, non-finite number, Date/Map/class
+     * instance, or a circular reference) — naming the input, its `until` target
+     * if any, the FSM id, and the exact value path. Throws for an Fsm child
+     * that's on `client`'s active path *relative to the true root* (consistent
+     * with `rehydrate()`'s conditional throw) — an Fsm owns its own context, so
+     * there's nothing per-client to snapshot. An Fsm child declared at a state
+     * `client` never visited, OR nested under a `BehavioralFsm` child that is
+     * itself off-path from the root, is skipped rather than throwing — neither
+     * has any per-client state to lose, so one Fsm child anywhere in the
+     * hierarchy doesn't disable `dehydrate()` for clients that never reach that
+     * branch, no matter how deeply nested the Fsm child is.
+     *
+     * Meant for clients at rest between `handle()` calls — `currentActionArgs`
+     * (the in-flight args mid-handler) has no meaning here and is excluded.
+     *
+     * @param isOnActivePath - @internal Whether this FSM itself is currently
+     * reachable from the true root's active path. Defaults to `true` for the
+     * public entry point (this FSM IS the root from its own perspective); the
+     * `ChildLink` adapter passes `false` down when recursing into a nested
+     * `BehavioralFsm` child that is itself off-path, so that child's own
+     * Fsm-child checks don't recompute reachability from its dormant local
+     * state alone.
+     */
+    dehydrate(client: TClient, isOnActivePath = true): ClientSnapshot | undefined {
+        const meta = this.clients.get(client);
+        if (!meta) {
+            return undefined;
+        }
+
+        const snapshot: ClientSnapshot = {
+            state: meta.state,
+            deferred: meta.deferredQueue.map(item => this.snapshotDeferredInput(item)),
+        };
+
+        const children = this.collectChildSnapshots(client, meta.state, isOnActivePath);
+        if (children) {
+            snapshot.children = children;
+        }
+
+        return snapshot;
+    }
+
+    /**
+     * @internal
+     * Validates `snapshot` against this level's state graph and recurses into
+     * every declared child, returning write thunks to run only once the WHOLE
+     * tree — every level — validates successfully. Nothing is written here.
+     * Called by the object-form of `rehydrate()` and, recursively, by ChildLink
+     * so a nested BehavioralFsm participates in the same validate-then-write
+     * pass. Not part of the public persistence API — call `rehydrate()` instead.
+     */
+    planSnapshotWrites(client: TClient, snapshot: ClientSnapshot): Array<() => void> {
+        if (this.disposed) {
+            // Mirrors the string form: a disposed FSM mid-hierarchy silently
+            // contributes no writes rather than blocking the rest of the tree.
+            return [];
+        }
+
+        const { state, deferred, children } = snapshot;
+
+        // Object.hasOwn (not `in`) — `in` walks the prototype chain, so a
+        // snapshot with state: "__proto__" (or "constructor", "toString", ...)
+        // would pass validation via the inherited Object.prototype member even
+        // though no state literally named that was ever declared.
+        if (!Object.hasOwn(this.states, state)) {
+            throw new Error(
+                `rehydrate: unknown state "${state}" in FSM "${this.id}". ` +
+                    `Valid states: ${Object.keys(this.states).join(", ")}`
+            );
+        }
+
+        const writes: Array<() => void> = [];
+
+        if (children) {
+            for (const stateName of Object.keys(children)) {
+                if (!Object.hasOwn(this.states, stateName)) {
+                    throw new Error(
+                        `rehydrate: unknown state "${stateName}" in FSM "${this.id}" ` +
+                            `referenced by snapshot.children.`
+                    );
+                }
+
+                const childLink = this.states[stateName]?._child as ChildLink | undefined;
+                if (!childLink) {
+                    throw new Error(
+                        `rehydrate: state "${stateName}" in FSM "${this.id}" has no _child, ` +
+                            `but the snapshot has a children["${stateName}"] entry.`
+                    );
+                }
+
+                writes.push(...childLink.planRehydrate(client, children[stateName]));
+            }
+        }
+
+        // Deep-clone args so the caller's snapshot object isn't aliased into live
+        // FSM state — a shallow spread only protects the array itself, not any
+        // nested objects/arrays inside it. cloneDeep() is validation-free (unlike
+        // dehydrate()'s cloneJsonSafe): rehydrate() trusts the snapshot is already
+        // valid data rather than re-validating on the way in.
+        const deferredQueue: DeferredInput[] = deferred.map(item => ({
+            inputName: item.inputName,
+            args: cloneDeep(item.args) as unknown[],
+            ...(item.untilState !== undefined ? { untilState: item.untilState } : {}),
+        }));
+
+        writes.push(() => {
+            // Guard knownClients before writing meta — if the client is already
+            // tracked, skip adding another WeakRef to avoid accumulating duplicates.
+            if (!this.clients.has(client)) {
+                this.knownClients.add(new WeakRef(client));
+            }
+            this.clients.set(client, { state: state as TStateNames, deferredQueue });
+        });
+
+        return writes;
+    }
+
+    private rehydrateCompositePath(client: TClient, compositeState: string): void {
         const [state, ...rest] = compositeState.split(".");
 
         if (!(state in this.states)) {
@@ -328,6 +482,119 @@ export class BehavioralFsm<
             this.knownClients.add(new WeakRef(client));
         }
         this.clients.set(client, { state: state as TStateNames, deferredQueue: [] });
+    }
+
+    /**
+     * Walks every declared state's `_child`, dehydrating each one that has ever
+     * seen `client`. The same child instance can be declared under multiple
+     * state names (shared child) — it's dehydrated once and the result is
+     * reused under every declaring state name, matching how the engine already
+     * treats shared children elsewhere (dispose, event subscriptions).
+     *
+     * Declaring names are grouped by `childLink.instance` (the actual FSM
+     * instance, not the `ChildLink` wrapper — `wrapChildLinks()` mints a fresh
+     * wrapper per declaring state, so grouping by wrapper would never hit for a
+     * shared child) BEFORE any `onPath` is computed or any child is dehydrated.
+     * A shared child's `onPath` is the OR of `stateName === activeState` across
+     * every declaring name in its group: at most one declaring name can ever
+     * equal `activeState`, so this combined flag is correct and, critically,
+     * independent of `Object.keys(this.states)` iteration order — computing
+     * `onPath` per-declaring-name and caching whichever one happened to run
+     * first would silently launder an on-path client's Fsm-child throw through
+     * an unrelated off-path declaring name.
+     *
+     * An off-path Fsm child (declared only at states other than `activeState`,
+     * OR nested anywhere under a `BehavioralFsm` child that is itself off-path
+     * relative to the true root) is skipped entirely rather than dehydrated:
+     * Fsm state isn't tracked per-client to begin with, so an off-path Fsm
+     * child has nothing to lose by being skipped — unlike a BehavioralFsm
+     * child's off-path meta, which is real per-client data. `isOnActivePath`
+     * is the inherited "am I even reachable from the root" flag; combining it
+     * with the group's `stateNames.includes(activeState)` check (rather than
+     * using that check alone) is what keeps a nested Fsm grandchild from
+     * throwing when its immediate BehavioralFsm parent is itself off-path —
+     * the parent's own dormant `activeState` is irrelevant once the parent
+     * isn't reachable. This keeps one Fsm child anywhere in the hierarchy from
+     * disabling `dehydrate()` for every client, only for clients actually on
+     * that branch.
+     */
+    private collectChildSnapshots(
+        client: TClient,
+        activeState: string,
+        isOnActivePath: boolean
+    ): Record<string, ClientSnapshot> | undefined {
+        // Pass 1: group every declaring state name by the child instance it
+        // resolves to, so a shared child's combined onPath can be computed
+        // before dehydrate() is ever called for it.
+        const declaringNamesByInstance = new Map<
+            MachinaInstance,
+            { childLink: ChildLink; stateNames: string[] }
+        >();
+
+        for (const stateName of Object.keys(this.states)) {
+            const childLink = this.states[stateName]?._child as ChildLink | undefined;
+            if (!childLink) {
+                continue;
+            }
+
+            const entry = declaringNamesByInstance.get(childLink.instance);
+            if (entry) {
+                entry.stateNames.push(stateName);
+            } else {
+                declaringNamesByInstance.set(childLink.instance, {
+                    childLink,
+                    stateNames: [stateName],
+                });
+            }
+        }
+
+        // Pass 2: dehydrate each unique instance exactly once, using the
+        // combined onPath, then fan the result out to every declaring name.
+        let children: Record<string, ClientSnapshot> | undefined;
+
+        for (const { childLink, stateNames } of declaringNamesByInstance.values()) {
+            const onPath = isOnActivePath && stateNames.includes(activeState);
+            const isOffPathFsmChild = childLink.instance[MACHINA_TYPE] === "Fsm" && !onPath;
+            if (isOffPathFsmChild) {
+                continue;
+            }
+
+            // Throws for an Fsm child that IS on the active path — propagates
+            // straight through, consistent with rehydrate()'s Fsm-child throw.
+            // `onPath` is passed down so a nested BehavioralFsm child applies
+            // the same root-relative reachability to its own Fsm children.
+            const childSnapshot = childLink.dehydrate(client, onPath);
+            if (childSnapshot) {
+                children ??= {};
+                for (const stateName of stateNames) {
+                    children[stateName] = childSnapshot;
+                }
+            }
+        }
+
+        return children;
+    }
+
+    private snapshotDeferredInput(item: DeferredInput): DeferredInput {
+        let clonedArgs: unknown[];
+        try {
+            clonedArgs = cloneJsonSafe(item.args, "args") as unknown[];
+        } catch (err) {
+            if (!(err instanceof NonSerializableValueError)) {
+                throw err;
+            }
+            const untilPart = item.untilState ? ` (until "${item.untilState}")` : "";
+            throw new Error(
+                `dehydrate: deferred input "${item.inputName}"${untilPart} in FSM "${this.id}" ` +
+                    `has a non-serializable value at ${err.path} (${err.label})`
+            );
+        }
+
+        const snapshot: DeferredInput = { inputName: item.inputName, args: clonedArgs };
+        if (item.untilState !== undefined) {
+            snapshot.untilState = item.untilState;
+        }
+        return snapshot;
     }
 
     /**
@@ -717,6 +984,12 @@ function createChildLink(child: any): ChildLink {
             rehydrate(client: object, compositeState: string): void {
                 child.rehydrate(client, compositeState);
             },
+            dehydrate(client: object, isOnActivePath: boolean): ClientSnapshot | undefined {
+                return child.dehydrate(client, isOnActivePath);
+            },
+            planRehydrate(client: object, snapshot: ClientSnapshot): Array<() => void> {
+                return child.planSnapshotWrites(client, snapshot);
+            },
             dispose(): void {
                 child.dispose();
             },
@@ -745,6 +1018,22 @@ function createChildLink(child: any): ChildLink {
                 // Fsm owns its context internally — there is no per-client state to restore.
                 // Rehydrating into a BehavioralFsm hierarchy that has Fsm children is a
                 // structural mismatch; throw immediately so the caller gets a clear signal.
+                throw new Error(
+                    `rehydrate: cannot rehydrate an Fsm child. Fsm owns its own context; ` +
+                        `rehydrate is only valid for BehavioralFsm hierarchies.`
+                );
+            },
+            dehydrate(_client: object, _isOnActivePath: boolean): ClientSnapshot | undefined {
+                // Fsm owns a single global context shared across every client of the
+                // parent BehavioralFsm — there's no per-client slice of it to snapshot.
+                // collectChildSnapshots() only reaches this call when onPath is true
+                // (it skips the call entirely otherwise), so this always throws.
+                throw new Error(
+                    `dehydrate: cannot dehydrate an Fsm child. Fsm owns its own context; ` +
+                        `dehydrate is only valid for BehavioralFsm hierarchies.`
+                );
+            },
+            planRehydrate(_client: object, _snapshot: ClientSnapshot): Array<() => void> {
                 throw new Error(
                     `rehydrate: cannot rehydrate an Fsm child. Fsm owns its own context; ` +
                         `rehydrate is only valid for BehavioralFsm hierarchies.`

--- a/packages/machina/src/index.ts
+++ b/packages/machina/src/index.ts
@@ -34,6 +34,8 @@ export type {
     ClientOf,
     DisposeOptions,
     ChildLink,
+    DeferredInput,
+    ClientSnapshot,
 } from "./types";
 
 // Runtime values used by inspection tooling

--- a/packages/machina/src/json-safe.test.ts
+++ b/packages/machina/src/json-safe.test.ts
@@ -1,0 +1,558 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export default {};
+
+import { cloneDeep, cloneJsonSafe, NonSerializableValueError } from "./json-safe";
+
+// =============================================================================
+// cloneJsonSafe()
+// =============================================================================
+
+describe("cloneJsonSafe", () => {
+    // =========================================================================
+    // Values that pass the walk
+    // =========================================================================
+
+    describe("when the value is null", () => {
+        let result: unknown;
+
+        beforeEach(() => {
+            result = cloneJsonSafe(null, "root");
+        });
+
+        it("should return null", () => {
+            expect(result).toBeNull();
+        });
+    });
+
+    describe("when the value is a boolean", () => {
+        let result: unknown;
+
+        beforeEach(() => {
+            result = cloneJsonSafe(false, "root");
+        });
+
+        it("should return the boolean unchanged", () => {
+            expect(result).toBe(false);
+        });
+    });
+
+    describe("when the value is a string", () => {
+        let result: unknown;
+
+        beforeEach(() => {
+            result = cloneJsonSafe("cal zone", "root");
+        });
+
+        it("should return the string unchanged", () => {
+            expect(result).toBe("cal zone");
+        });
+    });
+
+    describe("when the value is a finite number", () => {
+        let result: unknown;
+
+        beforeEach(() => {
+            result = cloneJsonSafe(8675309, "root");
+        });
+
+        it("should return the number unchanged", () => {
+            expect(result).toBe(8675309);
+        });
+    });
+
+    describe("when the value is a plain object with null-prototype", () => {
+        let source: object, result: unknown;
+
+        beforeEach(() => {
+            source = Object.assign(Object.create(null), { zip: "90210" });
+            result = cloneJsonSafe(source, "root");
+        });
+
+        it("should clone the object", () => {
+            expect(result).toEqual({ zip: "90210" });
+        });
+    });
+
+    describe("when the value is a deeply nested plain object/array combo", () => {
+        let source: Record<string, unknown>, result: unknown;
+
+        beforeEach(() => {
+            source = {
+                name: "Cal Zone",
+                tags: ["geeky", "playful", null],
+                address: {
+                    city: "Springfield",
+                    zip: "90210",
+                    nested: { deep: [1, 2, { ok: true }] },
+                },
+            };
+            result = cloneJsonSafe(source, "root");
+        });
+
+        it("should clone the full structure", () => {
+            expect(result).toEqual(source);
+        });
+
+        it("should return a new object, not the same reference", () => {
+            expect(result).not.toBe(source);
+        });
+
+        it("should return a new nested object, not an aliased reference", () => {
+            expect((result as any).address).not.toBe(source.address);
+        });
+
+        it("should return a new array, not an aliased reference", () => {
+            expect((result as any).tags).not.toBe(source.tags);
+        });
+    });
+
+    describe("when the same object reference appears twice without a cycle", () => {
+        let shared: Record<string, unknown>, result: unknown;
+
+        beforeEach(() => {
+            shared = { count: 1 };
+            result = cloneJsonSafe([shared, shared], "root");
+        });
+
+        it("should clone both occurrences without throwing", () => {
+            expect(result).toEqual([{ count: 1 }, { count: 1 }]);
+        });
+    });
+
+    // =========================================================================
+    // Values that throw — one test per distinct branch in cloneNode/cloneObject
+    // =========================================================================
+
+    describe("when the value is undefined", () => {
+        let thrownError: NonSerializableValueError;
+
+        beforeEach(() => {
+            try {
+                cloneJsonSafe(undefined, "args[0]");
+            } catch (e) {
+                thrownError = e as NonSerializableValueError;
+            }
+        });
+
+        it("should throw NonSerializableValueError with the undefined label", () => {
+            expect(thrownError).toBeInstanceOf(NonSerializableValueError);
+            expect(thrownError).toMatchObject({ path: "args[0]", label: "undefined" });
+        });
+    });
+
+    describe("when the value is a function", () => {
+        let thrownError: NonSerializableValueError;
+
+        beforeEach(() => {
+            try {
+                cloneJsonSafe(() => "kaboom", "args[1].onComplete");
+            } catch (e) {
+                thrownError = e as NonSerializableValueError;
+            }
+        });
+
+        it("should throw NonSerializableValueError with the function label", () => {
+            expect(thrownError).toBeInstanceOf(NonSerializableValueError);
+            expect(thrownError).toMatchObject({ path: "args[1].onComplete", label: "function" });
+        });
+    });
+
+    describe("when the value is a symbol", () => {
+        let thrownError: NonSerializableValueError;
+
+        beforeEach(() => {
+            try {
+                cloneJsonSafe(Symbol("E_SOGGY_STROMBOLI"), "root");
+            } catch (e) {
+                thrownError = e as NonSerializableValueError;
+            }
+        });
+
+        it("should throw NonSerializableValueError with the symbol label", () => {
+            expect(thrownError).toBeInstanceOf(NonSerializableValueError);
+            expect(thrownError).toMatchObject({ path: "root", label: "symbol" });
+        });
+    });
+
+    describe("when the value is a bigint", () => {
+        let thrownError: NonSerializableValueError;
+
+        beforeEach(() => {
+            try {
+                cloneJsonSafe(BigInt(90210), "root");
+            } catch (e) {
+                thrownError = e as NonSerializableValueError;
+            }
+        });
+
+        it("should throw NonSerializableValueError with the bigint label", () => {
+            expect(thrownError).toBeInstanceOf(NonSerializableValueError);
+            expect(thrownError).toMatchObject({ path: "root", label: "bigint" });
+        });
+    });
+
+    describe("when the value is NaN", () => {
+        let thrownError: NonSerializableValueError;
+
+        beforeEach(() => {
+            try {
+                cloneJsonSafe(NaN, "root");
+            } catch (e) {
+                thrownError = e as NonSerializableValueError;
+            }
+        });
+
+        it("should throw NonSerializableValueError with the NaN label", () => {
+            expect(thrownError).toBeInstanceOf(NonSerializableValueError);
+            expect(thrownError).toMatchObject({ path: "root", label: "NaN" });
+        });
+    });
+
+    describe("when the value is positive Infinity", () => {
+        let thrownError: NonSerializableValueError;
+
+        beforeEach(() => {
+            try {
+                cloneJsonSafe(Infinity, "root");
+            } catch (e) {
+                thrownError = e as NonSerializableValueError;
+            }
+        });
+
+        it("should throw NonSerializableValueError with the Infinity label", () => {
+            expect(thrownError).toBeInstanceOf(NonSerializableValueError);
+            expect(thrownError).toMatchObject({ path: "root", label: "Infinity" });
+        });
+    });
+
+    describe("when the value is negative Infinity", () => {
+        let thrownError: NonSerializableValueError;
+
+        beforeEach(() => {
+            try {
+                cloneJsonSafe(-Infinity, "root");
+            } catch (e) {
+                thrownError = e as NonSerializableValueError;
+            }
+        });
+
+        it("should throw NonSerializableValueError with the -Infinity label", () => {
+            expect(thrownError).toBeInstanceOf(NonSerializableValueError);
+            expect(thrownError).toMatchObject({ path: "root", label: "-Infinity" });
+        });
+    });
+
+    describe("when the value is a Date instance", () => {
+        let thrownError: NonSerializableValueError;
+
+        beforeEach(() => {
+            try {
+                cloneJsonSafe(new Date("1985-07-03"), "root");
+            } catch (e) {
+                thrownError = e as NonSerializableValueError;
+            }
+        });
+
+        it("should throw NonSerializableValueError with the constructor name as the label", () => {
+            expect(thrownError).toBeInstanceOf(NonSerializableValueError);
+            expect(thrownError).toMatchObject({ path: "root", label: "Date" });
+        });
+    });
+
+    describe("when the value is a Map instance", () => {
+        let thrownError: NonSerializableValueError;
+
+        beforeEach(() => {
+            try {
+                cloneJsonSafe(new Map([["cal", "zone"]]), "root");
+            } catch (e) {
+                thrownError = e as NonSerializableValueError;
+            }
+        });
+
+        it("should throw NonSerializableValueError with the constructor name as the label", () => {
+            expect(thrownError).toBeInstanceOf(NonSerializableValueError);
+            expect(thrownError).toMatchObject({ path: "root", label: "Map" });
+        });
+    });
+
+    describe("when the value is a class instance", () => {
+        class Robot {
+            model = "B-9";
+        }
+        let thrownError: NonSerializableValueError;
+
+        beforeEach(() => {
+            try {
+                cloneJsonSafe(new Robot(), "root");
+            } catch (e) {
+                thrownError = e as NonSerializableValueError;
+            }
+        });
+
+        it("should throw NonSerializableValueError with the class name as the label", () => {
+            expect(thrownError).toBeInstanceOf(NonSerializableValueError);
+            expect(thrownError).toMatchObject({ path: "root", label: "Robot" });
+        });
+    });
+
+    describe("when the value's prototype chain has no constructor", () => {
+        let thrownError: NonSerializableValueError;
+
+        beforeEach(() => {
+            // A non-null, non-Object.prototype proto with nothing in its own
+            // chain to name it — exercises the "constructor is missing" fallback.
+            const namelessProto = Object.create(null);
+            const obj = Object.create(namelessProto);
+            try {
+                cloneJsonSafe(obj, "root");
+            } catch (e) {
+                thrownError = e as NonSerializableValueError;
+            }
+        });
+
+        it("should throw NonSerializableValueError with a generic fallback label", () => {
+            expect(thrownError).toBeInstanceOf(NonSerializableValueError);
+            expect(thrownError).toMatchObject({ path: "root", label: "object" });
+        });
+    });
+
+    describe("when the value has a circular reference", () => {
+        let thrownError: NonSerializableValueError;
+
+        beforeEach(() => {
+            const circular: Record<string, unknown> = { name: "Cal Zone" };
+            circular.self = circular;
+            try {
+                cloneJsonSafe(circular, "root");
+            } catch (e) {
+                thrownError = e as NonSerializableValueError;
+            }
+        });
+
+        it("should throw NonSerializableValueError naming the exact cyclic path", () => {
+            expect(thrownError).toBeInstanceOf(NonSerializableValueError);
+            expect(thrownError).toMatchObject({ path: "root.self", label: "circular reference" });
+        });
+    });
+
+    describe("when a non-finite number is found deep in a nested structure", () => {
+        let thrownError: NonSerializableValueError;
+
+        beforeEach(() => {
+            try {
+                cloneJsonSafe({ retry: { onComplete: NaN } }, "args[1]");
+            } catch (e) {
+                thrownError = e as NonSerializableValueError;
+            }
+        });
+
+        it("should report the full dotted path to the offending value", () => {
+            expect(thrownError).toBeInstanceOf(NonSerializableValueError);
+            expect(thrownError).toMatchObject({ path: "args[1].retry.onComplete", label: "NaN" });
+        });
+    });
+
+    describe("when the value is a very deeply nested plain structure", () => {
+        let deep: unknown, result: unknown;
+
+        beforeEach(() => {
+            let node: Record<string, unknown> = { leaf: "Cal Zone" };
+            for (let i = 0; i < 2000; i++) {
+                node = { next: node };
+            }
+            deep = node;
+            result = cloneJsonSafe(deep, "root");
+        });
+
+        it("should clone the full depth without a stack overflow", () => {
+            expect(result).toEqual(deep);
+        });
+    });
+
+    // =========================================================================
+    // Regression guards for bugs found during hardening — the walk's stated
+    // contract is "throw the moment it finds anything that isn't [...] a
+    // plain array, or a plain object" (json-safe.ts:27-29). These three
+    // inputs ARE representable as plain JSON-shaped data (a sparse slot, an
+    // extra array property, a "__proto__"-named key); the walk previously
+    // silently dropped the offending data instead of throwing, contradicting
+    // that contract and the module's own stated purpose ("Silent loss is the
+    // disease this feature cures"). Now fixed: sparse/non-plain arrays throw,
+    // and "__proto__" is preserved as a real cloned data property.
+    // =========================================================================
+
+    describe("when the value is a sparse array with a hole", () => {
+        let thrownError: NonSerializableValueError | undefined;
+
+        beforeEach(() => {
+            thrownError = undefined;
+            const sparse = [1, , 3]; // eslint-disable-line no-sparse-arrays
+            try {
+                cloneJsonSafe(sparse, "root");
+            } catch (e) {
+                thrownError = e as NonSerializableValueError;
+            }
+        });
+
+        it("should throw rather than silently cloning the hole unexamined", () => {
+            expect(thrownError).toBeInstanceOf(NonSerializableValueError);
+        });
+    });
+
+    describe("when the value is an array with a non-index own property", () => {
+        let thrownError: NonSerializableValueError | undefined;
+
+        beforeEach(() => {
+            thrownError = undefined;
+            const withExtra: unknown[] & { extra?: string } = [1, 2];
+            withExtra.extra = "surprise";
+            try {
+                cloneJsonSafe(withExtra, "root");
+            } catch (e) {
+                thrownError = e as NonSerializableValueError;
+            }
+        });
+
+        // The fix rejects sparse holes AND non-index properties with the same
+        // length check (obj.length !== Object.keys(obj).length) — there's no
+        // way to throw for one and silently preserve the other, since both
+        // violate that equality identically. Throwing (not preserving) is the
+        // correct call here: a non-index property wouldn't survive a real
+        // JSON.stringify anyway, so "preserving" it in the in-memory clone
+        // would just move the silent loss to re-serialization time instead of
+        // eliminating it.
+        it("should throw rather than silently dropping the extra property", () => {
+            expect(thrownError).toBeInstanceOf(NonSerializableValueError);
+        });
+    });
+
+    describe('when the value is a plain object with a genuine own "__proto__" property', () => {
+        let hostile: Record<string, unknown>, cloned: Record<string, unknown>;
+
+        beforeEach(() => {
+            // Object literal syntax can't produce an OWN "__proto__" data property
+            // (it sets the prototype instead) — JSON.parse can, since it builds
+            // objects via CreateDataProperty rather than the assignment operator.
+            hostile = JSON.parse('{"__proto__":{"evil":true},"safe":"ok"}');
+            cloned = cloneJsonSafe(hostile, "root") as Record<string, unknown>;
+        });
+
+        it("should preserve '__proto__' as an own data property instead of silently reproto-ing the clone", () => {
+            expect(Object.prototype.hasOwnProperty.call(cloned, "__proto__")).toBe(true);
+        });
+
+        it("should leave the clone's actual prototype untouched", () => {
+            expect(Object.getPrototypeOf(cloned)).toBe(Object.prototype);
+        });
+    });
+});
+
+// =============================================================================
+// cloneDeep() — validation-free clone used by rehydrate()'s aliasing guard
+// =============================================================================
+
+describe("cloneDeep", () => {
+    describe("when the value is a primitive", () => {
+        let result: unknown;
+
+        beforeEach(() => {
+            result = cloneDeep("cal zone");
+        });
+
+        it("should return the primitive unchanged", () => {
+            expect(result).toBe("cal zone");
+        });
+    });
+
+    describe("when the value is a deeply nested plain object/array combo", () => {
+        let source: Record<string, unknown>, result: unknown;
+
+        beforeEach(() => {
+            source = {
+                name: "Cal Zone",
+                tags: ["geeky", "playful", null],
+                address: { city: "Springfield", zip: "90210" },
+            };
+            result = cloneDeep(source);
+        });
+
+        it("should clone the full structure", () => {
+            expect(result).toEqual(source);
+        });
+
+        it("should return a new object, not the same reference", () => {
+            expect(result).not.toBe(source);
+        });
+
+        it("should return a new nested object, not an aliased reference", () => {
+            expect((result as any).address).not.toBe(source.address);
+        });
+
+        it("should return a new array, not an aliased reference", () => {
+            expect((result as any).tags).not.toBe(source.tags);
+        });
+    });
+
+    describe("when the value is a non-plain object (e.g. a Date)", () => {
+        let source: Date, result: unknown;
+
+        beforeEach(() => {
+            source = new Date("1985-07-03");
+            result = cloneDeep(source);
+        });
+
+        it("should pass the value through by reference rather than cloning or throwing", () => {
+            expect(result).toBe(source);
+        });
+    });
+
+    describe("when the value has a circular reference", () => {
+        let circular: Record<string, unknown>, result: unknown;
+
+        beforeEach(() => {
+            circular = { name: "Cal Zone" };
+            circular.self = circular;
+            result = cloneDeep(circular);
+        });
+
+        it("should not throw or hang, and should keep the cyclic slot pointing at the original object", () => {
+            expect((result as any).self).toBe(circular);
+        });
+    });
+
+    describe('when the value has a genuine own "__proto__" property', () => {
+        let hostile: Record<string, unknown>, cloned: Record<string, unknown>;
+
+        beforeEach(() => {
+            hostile = JSON.parse('{"__proto__":{"evil":true},"safe":"ok"}');
+            cloned = cloneDeep(hostile) as Record<string, unknown>;
+        });
+
+        it("should preserve '__proto__' as an own data property instead of silently reproto-ing the clone", () => {
+            expect(Object.prototype.hasOwnProperty.call(cloned, "__proto__")).toBe(true);
+        });
+
+        it("should leave the clone's actual prototype untouched", () => {
+            expect(Object.getPrototypeOf(cloned)).toBe(Object.prototype);
+        });
+    });
+
+    describe("when the value is a sparse array with a hole", () => {
+        let sparse: unknown[], result: unknown;
+
+        beforeEach(() => {
+            sparse = [1, , 3]; // eslint-disable-line no-sparse-arrays
+            result = cloneDeep(sparse);
+        });
+
+        // Unlike cloneObject's array branch (used by cloneJsonSafe, which now
+        // rejects this input via the obj.length !== Object.keys(obj).length
+        // check), cloneDeep's array branch has no such check — it's
+        // validation-free by design, feeding rehydrate()'s trust-the-snapshot
+        // contract rather than dehydrate()'s throw-on-anything-unsafe one.
+        it("should reproduce the hole without throwing, unlike cloneJsonSafe's validating walk", () => {
+            expect(result).toEqual([1, undefined, 3]);
+        });
+    });
+});

--- a/packages/machina/src/json-safe.ts
+++ b/packages/machina/src/json-safe.ts
@@ -1,0 +1,186 @@
+// =============================================================================
+// json-safe.ts — Recursive walk that validates AND deep-clones plain data.
+//
+// dehydrate() needs a hard guarantee: everything it hands back either survives
+// a serialization boundary intact, or the call throws. JSON.stringify can't be
+// trusted for this — it silently drops functions/undefined and mangles Date
+// into a string. Silent data loss is exactly what dehydrate() exists to
+// prevent, so every unsupported value throws instead of vanishing, and the
+// error names precisely where in the structure it was found.
+// =============================================================================
+
+/**
+ * Thrown internally when the walk hits a value that can't survive a
+ * serialization boundary. Callers catch this to attach FSM/input context
+ * before re-throwing a fully descriptive error — see `path`/`label` below.
+ */
+export class NonSerializableValueError extends Error {
+    constructor(
+        readonly path: string,
+        readonly label: string
+    ) {
+        super(`non-serializable value at ${path} (${label})`);
+    }
+}
+
+/**
+ * Deep-clones `value`, throwing `NonSerializableValueError` the moment it
+ * finds anything that isn't `null`, a boolean, a finite number, a string, a
+ * plain array, or a plain object. `rootPath` seeds the path used in error
+ * messages — e.g. `"args"` so a nested failure reads as `args[1].onComplete`.
+ *
+ * Cloning (rather than just validating) is what keeps a returned snapshot
+ * from aliasing live FSM state: mutating the snapshot afterward — or the
+ * original value passed into a deferred `handle()` call — can't reach back
+ * into the FSM's internal deferred queue.
+ */
+export const cloneJsonSafe = (value: unknown, rootPath: string): unknown => {
+    return cloneNode(value, rootPath, new Set<object>());
+};
+
+const cloneNode = (value: unknown, path: string, ancestors: Set<object>): unknown => {
+    if (value === null) {
+        return null;
+    }
+
+    switch (typeof value) {
+        case "string":
+        case "boolean":
+            return value;
+        case "number":
+            if (!Number.isFinite(value)) {
+                throw new NonSerializableValueError(path, describeNonFiniteNumber(value));
+            }
+            return value;
+        case "object":
+            return cloneObject(value as object, path, ancestors);
+        default:
+            // undefined, function, symbol, bigint — none of these survive JSON.
+            throw new NonSerializableValueError(path, typeof value);
+    }
+};
+
+const cloneObject = (obj: object, path: string, ancestors: Set<object>): unknown => {
+    // Ancestor stack, not a global "seen" set — the same object appearing
+    // twice in unrelated branches (a shared reference) is fine to serialize
+    // twice. Only a value that contains ITSELF is a cycle.
+    if (ancestors.has(obj)) {
+        throw new NonSerializableValueError(path, "circular reference");
+    }
+
+    if (Array.isArray(obj)) {
+        // A dense, index-only array has exactly one own key per element
+        // ("0", "1", ...). A hole (sparse array) or an extra non-index
+        // property (obj.extra = ...) breaks that equality — `.map()` would
+        // otherwise skip holes and never visit non-index keys, silently
+        // reproducing (for holes) or dropping (for extra keys) data instead
+        // of throwing.
+        if (obj.length !== Object.keys(obj).length) {
+            throw new NonSerializableValueError(
+                path,
+                "sparse array or array with non-index properties"
+            );
+        }
+        ancestors.add(obj);
+        const cloned = obj.map((item, i) => cloneNode(item, `${path}[${i}]`, ancestors));
+        ancestors.delete(obj);
+        return cloned;
+    }
+
+    // Plain objects only — Date/Map/Set/class instances all have a
+    // non-Object prototype and would otherwise be silently flattened to
+    // "{}" by a naive walk.
+    const proto = Object.getPrototypeOf(obj);
+    if (proto !== Object.prototype && proto !== null) {
+        throw new NonSerializableValueError(
+            path,
+            (obj as { constructor?: { name?: string } }).constructor?.name ?? "object"
+        );
+    }
+
+    ancestors.add(obj);
+    const cloned: Record<string, unknown> = {};
+    for (const key of Object.keys(obj)) {
+        const value = cloneNode((obj as Record<string, unknown>)[key], `${path}.${key}`, ancestors);
+        // Object.defineProperty, not `cloned[key] = value` — a key literally
+        // named "__proto__" (producible via JSON.parse, unlike object-literal
+        // syntax) would otherwise invoke Object.prototype's inherited
+        // accessor and swap cloned's prototype instead of storing the data.
+        Object.defineProperty(cloned, key, {
+            value,
+            enumerable: true,
+            writable: true,
+            configurable: true,
+        });
+    }
+    ancestors.delete(obj);
+    return cloned;
+};
+
+const describeNonFiniteNumber = (n: number): string => {
+    if (Number.isNaN(n)) {
+        return "NaN";
+    }
+    return n > 0 ? "Infinity" : "-Infinity";
+};
+
+/**
+ * Deep-clones `value` WITHOUT validating it — unlike `cloneJsonSafe`, this
+ * never throws. Plain objects/arrays are cloned recursively (so a caller
+ * can't alias state back into whatever holds the result); anything else
+ * (functions, `Date`/`Map`/class instances, symbols, non-finite numbers,
+ * etc.) is passed through by reference as-is.
+ *
+ * This is `rehydrate()`'s side of the aliasing guarantee: `dehydrate()`
+ * validates-and-clones on the way OUT (via `cloneJsonSafe`), but `rehydrate()`
+ * trusts the snapshot it's given is already valid data — re-validating on
+ * the way IN would be a redundant, unwanted asymmetry (see the build plan's
+ * disclosed known gaps). We still need the clone so mutating the caller's
+ * snapshot object after `rehydrate()` returns can't reach into the live
+ * FSM's internal deferred queue.
+ *
+ * Cycle-safe: a value that contains itself is returned as-is (by reference)
+ * rather than cloned infinitely — there's no validation step here to make
+ * that throw, so silently keeping the shared reference is the only option
+ * that doesn't hang.
+ */
+export const cloneDeep = (value: unknown, ancestors: Set<object> = new Set<object>()): unknown => {
+    if (value === null || typeof value !== "object") {
+        return value;
+    }
+
+    if (ancestors.has(value)) {
+        return value;
+    }
+
+    if (Array.isArray(value)) {
+        ancestors.add(value);
+        const cloned = value.map(item => cloneDeep(item, ancestors));
+        ancestors.delete(value);
+        return cloned;
+    }
+
+    const proto = Object.getPrototypeOf(value);
+    if (proto !== Object.prototype && proto !== null) {
+        // Not a plain object (Date, Map, class instance, ...) — nothing to
+        // safely walk into, and there's no validation step here to reject it.
+        return value;
+    }
+
+    ancestors.add(value);
+    const cloned: Record<string, unknown> = {};
+    for (const key of Object.keys(value)) {
+        const clonedValue = cloneDeep((value as Record<string, unknown>)[key], ancestors);
+        // Same fix as cloneObject's loop in cloneJsonSafe: a key literally
+        // named "__proto__" would otherwise reproto the clone via bracket
+        // assignment instead of being stored as a data property.
+        Object.defineProperty(cloned, key, {
+            value: clonedValue,
+            enumerable: true,
+            writable: true,
+            configurable: true,
+        });
+    }
+    ancestors.delete(value);
+    return cloned;
+};

--- a/packages/machina/src/types.ts
+++ b/packages/machina/src/types.ts
@@ -484,6 +484,25 @@ export interface ChildLink {
      * Throws for Fsm children (no per-client state to rehydrate).
      */
     rehydrate(client: object, compositeState: string): void;
+    /**
+     * Snapshot everything this child tracks for `client`, recursing into its own
+     * children. `undefined` when the child has never seen this client. Throws for
+     * Fsm children that are on the active path — an Fsm owns its own context, so
+     * there's nothing per-client to snapshot. `isOnActivePath` is threaded down
+     * from the true root's dehydrate() call: it's `false` whenever ANY ancestor
+     * declaring state didn't match its own parent's active state, so a nested
+     * BehavioralFsm child correctly treats every one of its own Fsm children as
+     * off-path once the child itself is off-path, rather than recomputing
+     * reachability from its own (possibly dormant) state alone.
+     */
+    dehydrate(client: object, isOnActivePath: boolean): ClientSnapshot | undefined;
+    /**
+     * Validates `snapshot` against this child's state graph (recursing into its
+     * own children) and returns write thunks to run only once the ENTIRE tree
+     * validates — nothing is written here. Throws for Fsm children, matching
+     * `dehydrate()`.
+     */
+    planRehydrate(client: object, snapshot: ClientSnapshot): Array<() => void>;
     /** Dispose the child FSM */
     dispose(): void;
     /**
@@ -610,4 +629,42 @@ export interface ClientMeta<TStateNames extends string = string> {
      * can snapshot them for later replay. Cleared after dispatch.
      */
     currentActionArgs?: unknown[];
+}
+
+// -----------------------------------------------------------------------------
+// ClientSnapshot — the dehydrate()/rehydrate() persistence contract
+//
+// Everything machina tracks for one client, as plain serializable data.
+// Nested per hierarchy level: each FSM in the `_child` chain contributes its
+// own node, keyed by the PARENT state name that declares it. Deliberately
+// excludes `currentActionArgs` — that field only exists mid-handle() and has
+// no meaning for a client "at rest" between calls.
+// -----------------------------------------------------------------------------
+
+/**
+ * Plain-data snapshot of everything machina tracks for one client at a given
+ * level of the FSM hierarchy. Produced by `dehydrate()`, consumed by the
+ * object-overload of `rehydrate()`.
+ *
+ * `children` covers every state whose `_child` holds tracking data for this
+ * client — active or not. A child the client never reached has no entry
+ * (there's nothing to restore). This full-fidelity walk is what makes a
+ * rehydrated client behaviorally indistinguishable from one that never left
+ * memory: off-path child state and its pending deferrals travel too, and
+ * replay/reset exactly as they would have in-memory on the parent's next
+ * re-entry.
+ */
+export interface ClientSnapshot {
+    /** This level's state name (not the composite dot-path). */
+    state: string;
+
+    /** This level's pending deferred inputs, in FIFO replay order. */
+    deferred: DeferredInput[];
+
+    /**
+     * One entry per state (at this level) whose `_child` has tracking data
+     * for this client, keyed by that state's name. Omitted entirely when no
+     * state's child has ever seen this client.
+     */
+    children?: { [stateName: string]: ClientSnapshot };
 }


### PR DESCRIPTION
# Add BehavioralFsm client persistence (dehydrate/rehydrate)

**Branch**: behavioral-hydration -> master
**Changes**: 2892 additions, 12 deletions across 10 files

---

## Summary

### `59746b5` — Add BehavioralFsm client persistence: dehydrate() and snapshot-aware rehydrate()

**The mental model shift**

`rehydrate()` previously only restored composite state — a client's dot-path position in the FSM tree. Anything sitting in a client's deferred queue when it got persisted silently vanished on restore, because there was never a way to snapshot it in the first place. This commit closes that gap: `dehydrate(client)` returns everything machina tracks for a client — state, pending deferred inputs (args + `until` targets), and the same recursively for every `_child` in the hierarchy, active or not — as plain, JSON-serializable data. The object-form overload of `rehydrate()` restores it. A round-tripped client is now behaviorally indistinguishable from one that never left memory: off-path child state, stale-`_onExit`/no-op-`_onEnter` semantics on the parent's next re-entry, and deferred replay all survive the trip.

The core engine stays synchronous and storage-free, per the project's non-negotiables — machina hands back plain data, the app's repository layer owns the actual I/O via an explicit load → handle → save bracket (documented in the new guide page). None of this touches `handle()`/`transition()`; it's purely a save/restore seam bolted onto the existing per-client `WeakMap` tracking.

The `dehydrate()` side needed a real guarantee that `JSON.stringify` can't provide — it silently drops functions/`undefined` and mangles `Date` into a string, which is exactly the kind of silent data loss this feature exists to prevent. That's what the new `json-safe.ts` module is for: a recursive walk that validates *and* clones, throwing the moment it hits anything that can't survive a serialization boundary, with an error that names the precise value path (e.g. `args[1].onComplete`).

**What changed structurally**

1. **New `packages/machina/src/json-safe.ts`** (186 lines): `cloneJsonSafe()` — validates + deep-clones, throwing `NonSerializableValueError` for functions, `undefined`, symbols, bigints, non-finite numbers, `Date`/`Map`/class instances, circular references, sparse arrays, and arrays with non-index own properties. `cloneDeep()` — a validation-free sibling used on `rehydrate()`'s trusted input side (the snapshot is assumed already-valid data, so it clones without re-validating). Both use `Object.defineProperty` rather than bracket assignment when writing cloned keys, specifically to stop a key literally named `"__proto__"` from re-protoing the clone.
2. **`behavioral-fsm.ts`**: new public `dehydrate(client, isOnActivePath?)`; `rehydrate()` becomes an overloaded method (`string | ClientSnapshot`) dispatched on `typeof`, with the existing string form extracted unchanged into a private `rehydrateCompositePath()`. New `collectChildSnapshots()` does a two-pass walk that groups declaring state names by the *underlying child FSM instance* (not the per-declaring-state `ChildLink` wrapper) before computing `onPath` — this is what makes a shared child (same instance declared under two parent states) dedupe correctly and iteration-order-independently, rather than depending on whichever declaring name happens to be visited first. New `planSnapshotWrites()` validates the *entire* hierarchy and returns write thunks that only run once nothing has thrown, giving the object-form the same cross-level atomicity guarantee the string form gets "for free" from its children-first recursion. The `ChildLink` interface grows `dehydrate()`/`planRehydrate()`; the Fsm-child adapter throws for both (an Fsm owns its own global context — there's nothing per-client to snapshot).
3. **`types.ts`**: new recursive `ClientSnapshot` interface (`state` + `deferred` + optional `children` map); `DeferredInput` and `ClientSnapshot` newly exported from `index.ts`.
4. **Docs**: new guide page `guide/persisting-clients.mdx` (repository pattern, the load→handle→save service bracket, a concurrency/serial-processing caveat that's explicitly out of machina's scope) wired into the sidebar in `astro.config.mjs`; `behavioral-fsm.mdx` gets the two new API-table rows plus a "Snapshots" subsection. Incidental fix: removed a `dispose(client, options?)` row from the API table — that per-client overload doesn't actually exist in source (only whole-FSM `dispose(options?)` does).
5. **Changeset**: `machina` minor bump, targeting 6.4.0.

---

## Risk Callouts

- **New public API, additive and non-breaking.** `dehydrate()` is new; `rehydrate()`'s existing string-form signature and behavior are untouched — TS overload resolution still routes existing string-only call sites (e.g. the job-queue example's `fsm.rehydrate(job, persisted.state)`) to the original code path.
- **Disclosed API-surface leak (accepted tradeoff): `planSnapshotWrites()` is public, not private, on `BehavioralFsm`.** It has to be, because `ChildLink` adapters are built by a plain factory function outside the class and can only call public members — the same constraint the pre-existing `rehydrate(client, compositeState)` already lives under for the same reason. It's marked `@internal` in JSDoc and documented as "not part of the public persistence API," but it will show up in the `.d.ts` and generated typedoc output (there's no repo convention yet to exclude `@internal`-tagged members from typedoc generation). This was raised and accepted in the dev report as consistent with the existing precedent of publicly exposing `states` for tooling — flagging here for visibility, not blocking.
- **No data leakage in thrown errors.** `dehydrate()`/`cloneJsonSafe()` error messages name a value's *structural path* and type/label (`args[1].onComplete (function)`) — never the value's actual contents.
- **No new dependencies, no I/O, no async surface.** The core stays synchronous and storage-free, matching the build plan's explicit non-goals (no storage I/O, no identity keying, no async API, no serial-processing machinery in the core).

**Known scope exclusions (deliberate, not addressed in this PR):**

1. `transition()` and the private `rehydrateCompositePath()` still validate state names with the `in` operator, which shares the same prototype-chain weakness that `planSnapshotWrites()` fixes via `Object.hasOwn()` (a state name literally `"__proto__"` would pass the old-style check via the inherited `Object.prototype` member). Left untouched — out of scope for this feature.
2. The job-queue example does not yet adopt the new snapshot round-trip — it still persists composite state only. Planned as a separate follow-up PR.
3. `setupChildSubscriptions()` still dedupes shared children by `ChildLink` wrapper identity, which has the same shared-child-declared-at-multiple-states issue that `collectChildSnapshots()` had to be rewritten to avoid (grouping by the underlying child instance instead of the per-declaring-state wrapper). Deliberately not touched here.

---

## Tribal Knowledge Checks

### General Checks
- [x] **New environment variables**: None introduced.
- [x] **Type safety**: New `as`/type-assertion usage in the diff is consistent with the codebase's pre-existing pattern of internal casts in `behavioral-fsm.ts` (e.g. `_child as ChildLink | undefined`); no new `any`/`@ts-ignore`/`@ts-expect-error`.
- [x] **Dead code**: No unreferenced exports found. `planSnapshotWrites` is public (see Risk Callouts) but is actively called by `ChildLink`'s `planRehydrate` adapter — not dead.
- [x] **Dependency changes**: None. `json-safe.ts` has zero external imports.
- [x] **Leftover debugging**: No `console.*`, `debugger`, or `.only(` in the diff.
- [ ] **Breaking interface changes**: See Risk Callouts — `rehydrate()`'s new overload is additive/non-breaking, but flagging per the check's intent since it does change the method's type signature.
- [x] **Large binary/asset additions**: None.

### Unit Test Checks
- [x] **Style guide adherence**: Sampled describe blocks (`behavioral-fsm.test.ts`, `json-safe.test.ts`) construct the FSM/state-under-test in `beforeEach` and assert only in `it()`; both files include the required `export default {};`. Coverage is exhaustive relative to the build plan's test matrix (shared-child dedup ordering, `__proto__`/`hasOwnProperty` prototype-pollution edge cases, sparse arrays, circular refs, 3-level nesting, disposed-FSM no-ops) — already vetted through 4 review rounds and 2 dedicated test-hardening passes, both PASS.
- [x] **No testing pure style hooks / barrel exports**: N/A — no `.tsx` or barrel-export files touched.
- [x] **Test descriptions match assertions**: No mismatches found in sampled blocks.
- [x] **`export default {}`**: Present in both `behavioral-fsm.test.ts` and `json-safe.test.ts`.

---

## Testing Recommendations

Test coverage here is already unusually thorough — 367/367 tests passing after 4 review rounds and 2 dedicated test-hardening passes that specifically adversarially targeted prototype-pollution state names, shared-child dedup ordering, and sparse-array/circular-reference edge cases. The gaps below are things the unit suite structurally can't cover, not holes in it:

- **Manual: build the docs site.** `pnpm --filter docs build` (or dev server) and load `/guide/persisting-clients/` — it's a brand-new page wired into `astro.config.mjs`'s sidebar, and `behavioral-fsm.mdx` had a table row removed and a new section added. Confirm the Starlight build and nav aren't broken.
- **Regression, low-risk but worth a manual pass:** the job-queue example's existing `fsm.rehydrate(job, persisted.state)` call site is string-only and should be unaffected by `rehydrate()` becoming an overloaded method. `pnpm run checks` already covers this via typecheck + build, but worth eyeballing given the signature change.
- **Manual, if/when the job-queue follow-up PR happens:** exercise a `dehydrate()` → `JSON.stringify` → `localStorage` → `JSON.parse` → `rehydrate()` round-trip in an actual browser, not just the in-memory round-trip the unit tests cover — that's the one example built specifically to demonstrate this feature end-to-end, and it doesn't use the new snapshot form yet.
